### PR TITLE
Place source and build products in OUT_DIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ cblas = []
 lapacke = []
 static = []
 system = []
+shared-build-cache = []
 
 [dev-dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ The following Cargo features are supported:
 
 * `cblas` to build CBLAS (enabled by default),
 * `lapacke` to build LAPACKE (enabled by default),
-* `static` to link to OpenBLAS statically, and
-* `system` to skip building the bundled OpenBLAS.
+* `static` to link to OpenBLAS statically,
+* `system` to skip building the bundled OpenBLAS, and
+* `shared-build-cache` to place most of the OpenBLAS build products in
+  `~/.cargo` instead of the `target` directory. (This allows them to be reused
+  between crates which have different `target` directories, in order to avoid
+  rebuilding OpenBLAS unnecessarily. However, it prevents `cargo clean` from
+  removing the OpenBLAS build products.)
 
 ## Cross Compilation
 

--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,7 @@ fn main() {
             _ => variable!("TARGET"),
         };
         env::remove_var("TARGET");
-        let source = PathBuf::from(format!("source_{}", target.to_lowercase()));
+        let source = output.join(format!("source_{}", target.to_lowercase()));
         if !source.exists() {
             let source_tmp = PathBuf::from(format!("{}_tmp", source.display()));
             if source_tmp.exists() {

--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,11 @@ fn main() {
             _ => variable!("TARGET"),
         };
         env::remove_var("TARGET");
-        let source = output.join(format!("source_{}", target.to_lowercase()));
+        let source = if feature!("SHARED_BUILD_CACHE") {
+            PathBuf::from(format!("source_{}", target.to_lowercase()))
+        } else {
+            output.join(format!("source_{}", target.to_lowercase()))
+        };
         if !source.exists() {
             let source_tmp = PathBuf::from(format!("{}_tmp", source.display()));
             if source_tmp.exists() {


### PR DESCRIPTION
This has two benefits:

* It follows the directions specified in the Cargo docs. (["Build scripts may save any output files in the directory specified in the `OUT_DIR` environment variable. Scripts should not modify any files outside of that directory."](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script))

* It makes `cargo clean` work properly. (When build products are placed outside of `OUT_DIR`, `cargo clean` cannot remove them, which can make issues very difficult to debug.)