### PR TITLE
Include compiler versions in build directory name

### DIFF
--- a/make_build_info
+++ b/make_build_info
@@ -1,0 +1,56 @@
+ifndef TOPDIR
+TOPDIR = source
+endif
+
+include $(TOPDIR)/Makefile.system
+
+.PHONY: echo-build-info
+
+# Print build options and compiler versions to stdout. The compilers are
+# selected by the `include $(TOPDIR)/Makefile.system` above and written to
+# variables. Unfortunately, including `Makefile.system` has the side effect of
+# creating `$(TOPDIR)/Makefile.conf` and `$(TOPDIR)/config.h`, which should be
+# cleaned up afterward.
+echo-build-info :
+	@echo "OS: $(OSNAME)             "
+	@echo "Architecture: $(ARCH)               "
+ifndef BINARY64
+	@echo "Binary: 32bit                 "
+else
+	@echo "Binary: 64bit                 "
+endif
+
+ifdef INTERFACE64
+ifneq ($(INTERFACE64), 0)
+	@echo "Use 64 bits int    (equivalent to \"-i8\" in Fortran)      "
+endif
+endif
+
+ifndef SMP
+	@echo "Threading: Single threaded  "
+else
+	@echo "Threading: Multi threaded; Max num-threads is $(NUM_THREADS)"
+endif
+
+ifeq ($(USE_OPENMP), 1)
+	@echo "Use OpenMP: yes"
+else
+	@echo "Use OpenMP: no"
+endif
+
+	@echo
+	@echo "CC compiler: $(C_COMPILER)"
+	@echo "CC command line: $(CC)"
+	@echo
+	$(CC) --version
+	@echo
+ifeq ($(NOFORTRAN), $(filter 0,$(NOFORTRAN)))
+	@echo "FC compiler: $(F_COMPILER)"
+	@echo "FC command line: $(FC)"
+	@echo
+	$(FC) --version
+	@echo
+endif
+	@echo "HOSTCC command line: $(HOSTCC)"
+	@echo
+	$(HOSTCC) --version


### PR DESCRIPTION
Before, the build script ignored differing versions of the C and Fortran compilers; it built OpenBLAS in a directory named only by the target. Now, the build script gets information about the build environment, including the C and Fortran compiler versions, and includes a hash of that information in the build directory name. It also writes the build information to a file named `.openblas-src_build_info` in the build directory to help with debugging.

The result of this change is that when the C or Fortran compiler is changed (e.g. by a system update or by the user specifying the compiler version in environment variables), OpenBLAS will be rebuilt.

The hasher selected for hashing the build information is `std::collections::hash_map::DefaultHasher::new()` simply because it's included in the standard library, so the build script doesn't need extra dependencies. The disadvantage of this hasher is that its output is not guaranteed to be stable across different Rust releases. As a result, with a new Rust release, OpenBLAS may be rebuilt unnecessarily.