### PR TITLE
Cleanup openblas-src 'system' part

### DIFF
--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -2,6 +2,7 @@
 name = "openblas-src"
 version = "0.10.1"
 license = "Apache-2.0/MIT"
+edition = "2018"
 authors = [
     "Corey Richardson <corey@octayn.net>",
     "Ethan Smith <ethan@ethanhs.me>",

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -1,110 +1,143 @@
-use std::env;
-use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
+use std::{env, fs, path::*, process::Command};
 
-macro_rules! binary(() => (if cfg!(target_pointer_width = "32") { "32" } else { "64" }));
-macro_rules! feature(($name:expr) => (env::var(concat!("CARGO_FEATURE_", $name)).is_ok()));
-macro_rules! switch(($condition:expr) => (if $condition { "YES" } else { "NO" }));
-macro_rules! variable(($name:expr) => (env::var($name).unwrap()));
+fn feature_enabled(feature: &str) -> bool {
+    env::var(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_ok()
+}
+
+fn binary() -> &'static str {
+    if cfg!(target_pointer_width = "32") {
+        "32"
+    } else {
+        "64"
+    }
+}
+
+/// Add path where pacman (on msys2) install OpenBLAS
+///
+/// - `pacman -S mingw-w64-x86_64-openblas` will install
+///   - `libopenbla.dll` into `/mingw64/bin`
+///   - `libopenbla.a`   into `/mingw64/lib`
+/// - But we have to specify them using `-L` in **Windows manner**
+///   - msys2 `/` is `C:\msys64\` in Windows by default install
+///   - It can be convert using `cygpath` command
+fn windows_gnu_system() {
+    let lib_path = String::from_utf8(
+        Command::new("cygpath")
+            .arg("-w")
+            .arg(if feature_enabled("static") {
+                "/mingw64/bin"
+            } else {
+                "/mingw64/lib"
+            })
+            .output()
+            .expect("Failed to exec cygpath")
+            .stdout,
+    )
+    .expect("cygpath output includes non UTF-8 string");
+    println!("cargo:rustc-link-search={}", lib_path);
+}
+
+/// Use vcpkg for msvc "system" feature
+fn windows_msvc_system() {
+    if feature_enabled("static") {
+        env::set_var("CARGO_CFG_TARGET_FEATURE", "crt-static");
+    } else {
+        env::set_var("VCPKGRS_DYNAMIC", "1");
+    }
+    #[cfg(target_env = "msvc")]
+    vcpkg::find_package("openblas").unwrap();
+    if !cfg!(target_env = "msvc") {
+        unreachable!();
+    }
+}
+
+/// homebrew says
+///
+/// > openblas is keg-only, which means it was not symlinked into /usr/local,
+/// > because macOS provides BLAS in Accelerate.framework.
+/// > For compilers to find openblas you may need to set:
+///
+/// ```text
+/// export LDFLAGS="-L/usr/local/opt/openblas/lib"
+/// export CPPFLAGS="-I/usr/local/opt/openblas/include"
+/// ```
+fn macos_system() {
+    println!("cargo:rustc-link-search=/usr/local/opt/openblas/lib");
+}
 
 fn main() {
-    let kind = if feature!("STATIC") {
+    let link_kind = if feature_enabled("static") {
         "static"
     } else {
         "dylib"
     };
-    if feature!("SYSTEM") {
-        if cfg!(target_env = "msvc") {
-            if kind == "dylib" {
-                env::set_var("VCPKGRS_DYNAMIC", "1");
+    if feature_enabled("system") {
+        if cfg!(target_os = "windows") {
+            if cfg!(target_env = "gnu") {
+                windows_gnu_system();
+            } else if cfg!(target_env = "msvc") {
+                windows_msvc_system();
             } else {
-                env::set_var("CARGO_CFG_TARGET_FEATURE", "crt-static");
-            }
-            #[cfg(target_env = "msvc")]
-            vcpkg::find_package("openblas").unwrap();
-        }
-
-        // Add path where pacman (on msys2) install OpenBLAS
-        //
-        // - `pacman -S mingw-w64-x86_64-openblas` will install
-        //   - `libopenbla.dll` into `/mingw64/bin`
-        //   - `libopenbla.a`   into `/mingw64/lib`
-        // - But we have to specify them using `-L` in **Windows manner**
-        //   - msys2 `/` is `C:\msys64\` in Windows by default install
-        //   - It can be convert using `cygpath` command
-        if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
-            if kind == "dylib" {
-                let lib_path = String::from_utf8(
-                    Command::new("cygpath")
-                        .arg("-w")
-                        .arg("/mingw64/bin")
-                        .output()
-                        .expect("Failed to exec cygpath")
-                        .stdout,
-                )
-                .unwrap();
-                println!("cargo:rustc-link-search={}", lib_path);
-            } else {
-                let lib_path = String::from_utf8(
-                    Command::new("cygpath")
-                        .arg("-w")
-                        .arg("/mingw64/lib")
-                        .output()
-                        .expect("Failed to exec cygpath")
-                        .stdout,
-                )
-                .unwrap();
-                println!("cargo:rustc-link-search={}", lib_path);
+                panic!(
+                    "Unsupported ABI for Windows: {}",
+                    env::var("CARGO_CFG_TARGET_ENV").unwrap()
+                );
             }
         }
-
-        // homebrew will says
-        //
-        // > openblas is keg-only, which means it was not symlinked into /usr/local,
-        // > because macOS provides BLAS in Accelerate.framework.
-        // > For compilers to find openblas you may need to set:
-        //
-        // ```
-        // export LDFLAGS="-L/usr/local/opt/openblas/lib"
-        // export CPPFLAGS="-I/usr/local/opt/openblas/include"
-        // ```
-        //
         if cfg!(target_os = "macos") {
-            println!("cargo:rustc-link-search=/usr/local/opt/openblas/lib");
+            macos_system();
         }
+        println!("cargo:rustc-link-lib={}=openblas", link_kind);
     } else {
         if cfg!(target_env = "msvc") {
-            panic!("Non-vcpkg builds are not supported on Windows (you must use the \"system\" feature.")
+            panic!(
+                "Non-vcpkg builds are not supported on Windows. You must use the 'system' feature."
+            )
         }
-        let cblas = feature!("CBLAS");
-        let lapacke = feature!("LAPACKE");
-        let output = PathBuf::from(variable!("OUT_DIR").replace(r"\", "/"));
+
+        let output = PathBuf::from(env::var("OUT_DIR").unwrap().replace(r"\", "/"));
         let mut make = Command::new("make");
         make.args(&["libs", "netlib", "shared"])
-            .arg(format!("BINARY={}", binary!()))
-            .arg(format!("{}_CBLAS=1", switch!(cblas)))
-            .arg(format!("{}_LAPACKE=1", switch!(lapacke)));
+            .arg(format!("BINARY={}", binary()))
+            .arg(format!(
+                "{}_CBLAS=1",
+                if feature_enabled("cblas") {
+                    "YES"
+                } else {
+                    "NO"
+                }
+            ))
+            .arg(format!(
+                "{}_LAPACKE=1",
+                if feature_enabled("lapacke") {
+                    "YES"
+                } else {
+                    "NO"
+                }
+            ));
         match env::var("OPENBLAS_ARGS") {
             Ok(args) => {
                 make.args(args.split_whitespace());
             }
             _ => (),
         };
-        make.arg(format!("-j{}", variable!("NUM_JOBS")));
+        if let Ok(num_jobs) = env::var("NUM_JOBS") {
+            make.arg(format!("-j{}", num_jobs));
+        }
         let target = match env::var("OPENBLAS_TARGET") {
             Ok(target) => {
                 make.arg(format!("TARGET={}", target));
                 target
             }
-            _ => variable!("TARGET"),
+            _ => env::var("TARGET").unwrap(),
         };
         env::remove_var("TARGET");
-        let source = if feature!("CACHE") {
+        let source = if feature_enabled("cache") {
             PathBuf::from(format!("source_{}", target.to_lowercase()))
         } else {
             output.join(format!("source_{}", target.to_lowercase()))
         };
+
         if !source.exists() {
             let source_tmp = PathBuf::from(format!("{}_tmp", source.display()));
             if source_tmp.exists() {
@@ -127,8 +160,8 @@ fn main() {
             "cargo:rustc-link-search={}",
             output.join("opt/OpenBLAS/lib").display(),
         );
-    };
-    println!("cargo:rustc-link-lib={}=openblas", kind);
+    }
+    println!("cargo:rustc-link-lib={}=openblas", link_kind);
 }
 
 fn run(command: &mut Command) {


### PR DESCRIPTION
For #44, split from https://github.com/termoshtt/openblas-src/pull/3

Summary
-------------
- Replace `feature!` and other macros, which can be usual function
- Split each target-specific parts into functions