### PR TITLE
Switch to openblas-build on Linux

### DIFF
--- a/.github/workflows/openblas-src.yml
+++ b/.github/workflows/openblas-src.yml
@@ -82,6 +82,10 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: 'recursive'
+    - name: Install GCC-Fortran by apt
+      run: |
+        apt update
+        apt install -y gfortran
     - name: Install OpenBLAS by apt
       run: |
         apt update

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -241,11 +241,15 @@ impl Configure {
         // - This will automatically run in parallel without `-j` flag
         // - The `make` of OpenBLAS outputs 30k lines,
         //   which will be redirected into `out.log` and `err.log`.
+        // - cargo sets `TARGET` environment variable as target triple (e.g. x86_64-unknown-linux-gnu)
+        //   while binding build.rs, but `make` read it as CPU target specification.
+        //
         match Command::new("make")
             .current_dir(out_dir)
             .stdout(unsafe { Stdio::from_raw_fd(out.into_raw_fd()) }) // this works only for unix
             .stderr(unsafe { Stdio::from_raw_fd(err.into_raw_fd()) })
             .args(&self.make_args())
+            .env_remove("TARGET")
             .check_call()
         {
             Ok(_) => {}
@@ -290,6 +294,14 @@ impl Configure {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[ignore]
+    #[test]
+    fn build_default() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_build/build_default");
+        let opt = Configure::default();
+        let _detail = opt.build(path).unwrap();
+    }
 
     #[ignore]
     #[test]

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -48,3 +48,6 @@ libc = "0.2"
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"
+
+[target.'cfg(target_os="linux")'.build-dependencies.openblas-build]
+path = "../openblas-build"

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -108,6 +108,7 @@ fn build() {
         cfg.no_static = true;
     }
     cfg.build(&output).unwrap();
+    println!("cargo:rustc-link-search={}", output.display());
 }
 
 /// openblas-src 0.9.0 compatible `make` runner

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -120,7 +120,18 @@ fn run(command: &mut Command) {
 /// Build OpenBLAS using openblas-build crate
 fn build() {
     let output = PathBuf::from(env::var("OUT_DIR").unwrap()).join("OpenBLAS");
-    let cfg = openblas_build::Configure::default();
+    let mut cfg = openblas_build::Configure::default();
+    if !feature_enabled("cblas") {
+        cfg.no_cblas = true;
+    }
+    if !feature_enabled("lapacke") {
+        cfg.no_lapacke = true;
+    }
+    if feature_enabled("static") {
+        cfg.no_shared = true;
+    } else {
+        cfg.no_static = true;
+    }
     cfg.build(&output).unwrap();
 }
 

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -94,7 +94,11 @@ fn main() {
                 "Non-vcpkg builds are not supported on Windows. You must use the 'system' feature."
             )
         }
-        naive_build();
+        if cfg!(target_os = "linux") {
+            build();
+        } else {
+            naive_build();
+        }
     }
     println!("cargo:rustc-link-lib={}=openblas", link_kind);
 }
@@ -111,6 +115,13 @@ fn run(command: &mut Command) {
             panic!("Failed: `{:?}` ({})", command, error);
         }
     }
+}
+
+/// Build OpenBLAS using openblas-build crate
+fn build() {
+    let output = PathBuf::from(env::var("OUT_DIR").unwrap()).join("OpenBLAS");
+    let cfg = openblas_build::Configure::default();
+    cfg.build(&output).unwrap();
 }
 
 /// openblas-src 0.9.0 compatible `make` runner

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -94,72 +94,7 @@ fn main() {
                 "Non-vcpkg builds are not supported on Windows. You must use the 'system' feature."
             )
         }
-
-        let output = PathBuf::from(env::var("OUT_DIR").unwrap().replace(r"\", "/"));
-        let mut make = Command::new("make");
-        make.args(&["libs", "netlib", "shared"])
-            .arg(format!("BINARY={}", binary()))
-            .arg(format!(
-                "{}_CBLAS=1",
-                if feature_enabled("cblas") {
-                    "YES"
-                } else {
-                    "NO"
-                }
-            ))
-            .arg(format!(
-                "{}_LAPACKE=1",
-                if feature_enabled("lapacke") {
-                    "YES"
-                } else {
-                    "NO"
-                }
-            ));
-        match env::var("OPENBLAS_ARGS") {
-            Ok(args) => {
-                make.args(args.split_whitespace());
-            }
-            _ => (),
-        };
-        if let Ok(num_jobs) = env::var("NUM_JOBS") {
-            make.arg(format!("-j{}", num_jobs));
-        }
-        let target = match env::var("OPENBLAS_TARGET") {
-            Ok(target) => {
-                make.arg(format!("TARGET={}", target));
-                target
-            }
-            _ => env::var("TARGET").unwrap(),
-        };
-        env::remove_var("TARGET");
-        let source = if feature_enabled("cache") {
-            PathBuf::from(format!("source_{}", target.to_lowercase()))
-        } else {
-            output.join(format!("source_{}", target.to_lowercase()))
-        };
-
-        if !source.exists() {
-            let source_tmp = PathBuf::from(format!("{}_tmp", source.display()));
-            if source_tmp.exists() {
-                fs::remove_dir_all(&source_tmp).unwrap();
-            }
-            run(Command::new("cp").arg("-R").arg("source").arg(&source_tmp));
-            fs::rename(&source_tmp, &source).unwrap();
-        }
-        for name in &vec!["CC", "FC", "HOSTCC"] {
-            if let Ok(value) = env::var(format!("OPENBLAS_{}", name)) {
-                make.arg(format!("{}={}", name, value));
-            }
-        }
-        run(&mut make.current_dir(&source));
-        run(Command::new("make")
-            .arg("install")
-            .arg(format!("DESTDIR={}", output.display()))
-            .current_dir(&source));
-        println!(
-            "cargo:rustc-link-search={}",
-            output.join("opt/OpenBLAS/lib").display(),
-        );
+        naive_build();
     }
     println!("cargo:rustc-link-lib={}=openblas", link_kind);
 }
@@ -176,4 +111,73 @@ fn run(command: &mut Command) {
             panic!("Failed: `{:?}` ({})", command, error);
         }
     }
+}
+
+/// openblas-src 0.9.0 compatible `make` runner
+fn naive_build() {
+    let output = PathBuf::from(env::var("OUT_DIR").unwrap().replace(r"\", "/"));
+    let mut make = Command::new("make");
+    make.args(&["libs", "netlib", "shared"])
+        .arg(format!("BINARY={}", binary()))
+        .arg(format!(
+            "{}_CBLAS=1",
+            if feature_enabled("cblas") {
+                "YES"
+            } else {
+                "NO"
+            }
+        ))
+        .arg(format!(
+            "{}_LAPACKE=1",
+            if feature_enabled("lapacke") {
+                "YES"
+            } else {
+                "NO"
+            }
+        ));
+    match env::var("OPENBLAS_ARGS") {
+        Ok(args) => {
+            make.args(args.split_whitespace());
+        }
+        _ => (),
+    };
+    if let Ok(num_jobs) = env::var("NUM_JOBS") {
+        make.arg(format!("-j{}", num_jobs));
+    }
+    let target = match env::var("OPENBLAS_TARGET") {
+        Ok(target) => {
+            make.arg(format!("TARGET={}", target));
+            target
+        }
+        _ => env::var("TARGET").unwrap(),
+    };
+    env::remove_var("TARGET");
+    let source = if feature_enabled("cache") {
+        PathBuf::from(format!("source_{}", target.to_lowercase()))
+    } else {
+        output.join(format!("source_{}", target.to_lowercase()))
+    };
+
+    if !source.exists() {
+        let source_tmp = PathBuf::from(format!("{}_tmp", source.display()));
+        if source_tmp.exists() {
+            fs::remove_dir_all(&source_tmp).unwrap();
+        }
+        run(Command::new("cp").arg("-R").arg("source").arg(&source_tmp));
+        fs::rename(&source_tmp, &source).unwrap();
+    }
+    for name in &vec!["CC", "FC", "HOSTCC"] {
+        if let Ok(value) = env::var(format!("OPENBLAS_{}", name)) {
+            make.arg(format!("{}={}", name, value));
+        }
+    }
+    run(&mut make.current_dir(&source));
+    run(Command::new("make")
+        .arg("install")
+        .arg(format!("DESTDIR={}", output.display()))
+        .current_dir(&source));
+    println!(
+        "cargo:rustc-link-search={}",
+        output.join("opt/OpenBLAS/lib").display(),
+    );
 }

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -114,6 +114,10 @@ fn run(command: &mut Command) {
 }
 
 /// openblas-src 0.9.0 compatible `make` runner
+///
+/// This cannot detect that OpenBLAS skips LAPACK build due to the absense of Fortran compiler.
+/// openblas-build crate can detect it by sneaking OpenBLAS build system, but only works on Linux.
+///
 fn naive_build() {
     let output = PathBuf::from(env::var("OUT_DIR").unwrap().replace(r"\", "/"));
     let mut make = Command::new("make");

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -115,7 +115,7 @@ fn build() {
 /// This cannot detect that OpenBLAS skips LAPACK build due to the absense of Fortran compiler.
 /// openblas-build crate can detect it by sneaking OpenBLAS build system, but only works on Linux.
 ///
-#[cfg(target_os = "macos")]
+#[cfg(not(target_os = "linux"))]
 fn build() {
     use std::fs;
 


### PR DESCRIPTION
- Build OpenBLAS in openblas-src using openblas-build crate. #47 
- Use only for Linux because openblas-build does not work well on macOS https://github.com/blas-lapack-rs/openblas-src/issues/44#issuecomment-748438531
  - openblas-src 0.9 compatible build routine is left as `naive_build` and will be used for non-Linux and non-Windows platforms