### PR TITLE
Support cache feature for openblas-build

### DIFF
--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -22,14 +22,14 @@ fn openblas_source_dir() -> PathBuf {
 }
 
 /// Interface for 32-bit interger (LP64) and 64-bit integer (ILP64)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Interface {
     LP64,
     ILP64,
 }
 
 /// CPU list in [TargetList](https://github.com/xianyi/OpenBLAS/blob/v0.3.10/TargetList.txt)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(non_camel_case_types)] // to use original identifiers
 pub enum Target {
     // X86/X86_64 Intel
@@ -129,7 +129,7 @@ pub enum Target {
 }
 
 /// make option generator
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Configure {
     pub no_static: bool,
     pub no_shared: bool,

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -46,6 +46,9 @@ system = []
 [dev-dependencies]
 libc = "0.2"
 
+[build-dependencies]
+dirs = "3.0.1"
+
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"
 

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -1,4 +1,4 @@
-use std::{collections::hash_map::DefaultHasher, env, hash::*, path::*, process::Command};
+use std::{env, path::*, process::Command};
 
 fn feature_enabled(feature: &str) -> bool {
     env::var(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_ok()
@@ -108,6 +108,7 @@ fn build() {
     }
 
     let output = if feature_enabled("cache") {
+        use std::{collections::hash_map::DefaultHasher, hash::*};
         // Build OpenBLAS on user's data directory.
         // See https://docs.rs/dirs/3.0.1/dirs/fn.data_dir.html
         //


### PR DESCRIPTION
This PR includes breaking changes from 0.9.0's cache feature:

- 0.9.0 creates `source_${target-triple}` directory on *the build directory*, i.e. `PathBuf::from("source_...")` in build.rs. It changes how user build openblas-src.
- This PR change the directory of cache to `$XDG_DATA_HOME/openblas_build/${hash_of_configure}`, which will be shared among several projects using openblas-src on a same machine.