### PR TITLE
Print rustc-link-search for the in-tree static openblas before everything else

### DIFF
--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -149,6 +149,7 @@ fn build() {
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("source");
     let deliv = cfg.build(&source, &output).unwrap();
 
+    println!("cargo:rustc-link-search={}", output.display());
     for search_path in &deliv.make_conf.c_extra_libs.search_paths {
         println!("cargo:rustc-link-search={}", search_path.display());
     }
@@ -161,7 +162,6 @@ fn build() {
     for lib in &deliv.make_conf.f_extra_libs.libs {
         println!("cargo:rustc-link-lib={}", lib);
     }
-    println!("cargo:rustc-link-search={}", output.display());
 }
 
 /// openblas-src 0.9.0 compatible `make` runner


### PR DESCRIPTION
Fixes #60.

The gnu linker searches libraries in the order of `-L` options and stops
the search when the first matching library is found. This means if
`libopenblas.a` is either in `deliv.make_conf.c_extra_libs.search_path` or
in `deliv.make_conf.f_extra_libs.search_path`, the in-tree `libopenblas.a`
won't be used.

This patch fixes the issue by printing the `rustc-link-search` instruction
for the in-tree openblas before everything else.

I've confirmed that the reproducer in #60 now prints the same config string across all distributions:

```console
% git clone https://github.com/maoe/openblas-src.git
% cd openblas-src
% git checkout print-config-fix # this is the reproducer with this fix
% docker build -f Dockerfile.debian-bullseye -t openblas-src-bullseye .
% docker build -f Dockerfile.ubuntu-bionic -t openblas-src-bionic .
% docker build -f Dockerfile.ubuntu-focal -t openblas-src-focal .
% docker run -it --rm openblas-src-bullseye
OpenBLAS 0.3.10 NO_AFFINITY HASWELL MAX_THREADS=12
% docker run -it --rm openblas-src-bionic
OpenBLAS 0.3.10 NO_AFFINITY HASWELL MAX_THREADS=12
% docker run -it --rm openblas-src-focal
OpenBLAS 0.3.10 NO_AFFINITY HASWELL MAX_THREADS=12
```