### PR TITLE
CHANGELOG.md since 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ Unreleased
 --------------------
 
 ### Fixed
-- Change link search order #61
+- Change link search order https://github.com/blas-lapack-rs/openblas-src/pull/61
 
 0.10.3 - 2021-04-02
 -------------------
 
 ### Fixed
-- Update "cache" feature description #63
+- Update "cache" feature description https://github.com/blas-lapack-rs/openblas-src/pull/63
 
 ### Changed
-- Upgrade OpenBLAS to 0.3.14  #65
+- Upgrade OpenBLAS to 0.3.14  https://github.com/blas-lapack-rs/openblas-src/pull/65
 
 0.10.2 - 2021-01-30
 --------------------
@@ -26,17 +26,17 @@ Unreleased
 0.10.0 and 0.10.1 has been yanked and changes from 0.9.0 is summarized here.
 
 ### Fixed
-- Detect OpenBLAS does not build some parts of LAPACK while "lapack" feature is enabled #49
+- Detect OpenBLAS does not build some parts of LAPACK while "lapack" feature is enabled https://github.com/blas-lapack-rs/openblas-src/issues/49
   - openblas-build crate has been introduced to resolve this issue
 
 ### Added
 - openblas-build crate is introduced to sneak OpenBLAS build system configure
-  - Link test for LAPACK routines written in Fortran #43
-  - Switch to openblas-build on Linux #52
-    - Not on macOS due to #54
-  - Create openblas-build crate #47
-    - cargo-workspace setup #45
+  - Link test for LAPACK routines written in Fortran https://github.com/blas-lapack-rs/openblas-src/pull/43
+  - Switch to openblas-build on Linux https://github.com/blas-lapack-rs/openblas-src/pull/52
+    - Not on macOS due to https://github.com/blas-lapack-rs/openblas-src/issues/54
+  - Create openblas-build crate https://github.com/blas-lapack-rs/openblas-src/pull/47
+    - cargo-workspace setup https://github.com/blas-lapack-rs/openblas-src/pull/45
 
 ### Changed
-- Use Rust 2018 edition #46
-- Switch to GitHub Actions from AppVeyor + Travis CI #40
+- Use Rust 2018 edition https://github.com/blas-lapack-rs/openblas-src/pull/46
+- Switch to GitHub Actions from AppVeyor + Travis CI https://github.com/blas-lapack-rs/openblas-src/pull/40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,43 +6,37 @@ Unreleased
 -----------
 
 0.10.4 - 2021-04-03
-=====================
+--------------------
 
-Fixed
-------
-- Change link search order https://github.com/blas-lapack-rs/openblas-src/pull/61
+### Fixed
+- Change link search order #61
 
 0.10.3 - 2021-04-02
-=====================
+-------------------
 
-Fixed
-------
-- Update "cache" feature description https://github.com/blas-lapack-rs/openblas-src/pull/63
+### Fixed
+- Update "cache" feature description #63
 
-Changed
--------
-- Upgrade OpenBLAS to 0.3.14  https://github.com/blas-lapack-rs/openblas-src/pull/65
+### Changed
+- Upgrade OpenBLAS to 0.3.14  #65
 
 0.10.2 - 2021-01-30
-=====================
+--------------------
 
 0.10.0 and 0.10.1 has been yanked and changes from 0.9.0 is summarized here.
 
-Fixed
-------
-- Detect OpenBLAS does not build some parts of LAPACK while "lapack" feature is enabled https://github.com/blas-lapack-rs/openblas-src/issues/49
+### Fixed
+- Detect OpenBLAS does not build some parts of LAPACK while "lapack" feature is enabled #49
   - openblas-build crate has been introduced to resolve this issue
 
-Added
-------
+### Added
 - openblas-build crate is introduced to sneak OpenBLAS build system configure
-  - Link test for LAPACK routines written in Fortran https://github.com/blas-lapack-rs/openblas-src/pull/43
-  - Switch to openblas-build on Linux https://github.com/blas-lapack-rs/openblas-src/pull/52
-    - Not on macOS due to https://github.com/blas-lapack-rs/openblas-src/issues/54
-  - Create openblas-build crate https://github.com/blas-lapack-rs/openblas-src/pull/47
-    - cargo-workspace setup https://github.com/blas-lapack-rs/openblas-src/pull/45
+  - Link test for LAPACK routines written in Fortran #43
+  - Switch to openblas-build on Linux #52
+    - Not on macOS due to #54
+  - Create openblas-build crate #47
+    - cargo-workspace setup #45
 
-Changed
--------
-- Use Rust 2018 edition https://github.com/blas-lapack-rs/openblas-src/pull/46
-- Switch to GitHub Actions from AppVeyor + Travis CI https://github.com/blas-lapack-rs/openblas-src/pull/40
+### Changed
+- Use Rust 2018 edition #46
+- Switch to GitHub Actions from AppVeyor + Travis CI #40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,10 @@ Unreleased
 ### Changed
 - Use Rust 2018 edition https://github.com/blas-lapack-rs/openblas-src/pull/46
 - Switch to GitHub Actions from AppVeyor + Travis CI https://github.com/blas-lapack-rs/openblas-src/pull/40
+
+0.9.0 - 2020-03-08
+--------------------
+
+### Changed
+- Build products are placed on OUT_DIR to work `cargo clean` properly https://github.com/blas-lapack-rs/openblas-src/pull/31
+  - Previous behavior (placed on .cargo/) is reproduced with "cache" feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+These versions are based on [semantic versioning][semver], and corresponds to the version in `Cargo.toml`.
+
+[semver]: https://semver.org/
+
+Unreleased
+-----------
+
+0.10.4 - 2021-04-03
+=====================
+
+Fixed
+------
+- Change link search order https://github.com/blas-lapack-rs/openblas-src/pull/61
+
+0.10.3 - 2021-04-02
+=====================
+
+Fixed
+------
+- Update "cache" feature description https://github.com/blas-lapack-rs/openblas-src/pull/63
+
+Changed
+-------
+- Upgrade OpenBLAS to 0.3.14  https://github.com/blas-lapack-rs/openblas-src/pull/65
+
+0.10.2 - 2021-01-30
+=====================
+
+0.10.0 and 0.10.1 has been yanked and changes from 0.9.0 is summarized here.
+
+Fixed
+------
+- Detect OpenBLAS does not build some parts of LAPACK while "lapack" feature is enabled https://github.com/blas-lapack-rs/openblas-src/issues/49
+  - openblas-build crate has been introduced to resolve this issue
+
+Added
+------
+- openblas-build crate is introduced to sneak OpenBLAS build system configure
+  - Link test for LAPACK routines written in Fortran https://github.com/blas-lapack-rs/openblas-src/pull/43
+  - Switch to openblas-build on Linux https://github.com/blas-lapack-rs/openblas-src/pull/52
+    - Not on macOS due to https://github.com/blas-lapack-rs/openblas-src/issues/54
+  - Create openblas-build crate https://github.com/blas-lapack-rs/openblas-src/pull/47
+    - cargo-workspace setup https://github.com/blas-lapack-rs/openblas-src/pull/45
+
+Changed
+-------
+- Use Rust 2018 edition https://github.com/blas-lapack-rs/openblas-src/pull/46
+- Switch to GitHub Actions from AppVeyor + Travis CI https://github.com/blas-lapack-rs/openblas-src/pull/40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Unreleased
     - Not on macOS due to https://github.com/blas-lapack-rs/openblas-src/issues/54
   - Create openblas-build crate https://github.com/blas-lapack-rs/openblas-src/pull/47
     - cargo-workspace setup https://github.com/blas-lapack-rs/openblas-src/pull/45
+- "system" feature support for windows-msvc target through vcpkg https://github.com/blas-lapack-rs/openblas-src/pull/35
 
 ### Changed
 - Use Rust 2018 edition https://github.com/blas-lapack-rs/openblas-src/pull/46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-These versions are based on [semantic versioning][semver], and corresponds to the version in `Cargo.toml`.
+These versions are based on [semantic versioning][semver], and corresponds to the version in [openblas-src/Cargo.toml](openblas-src/Cargo.toml).
 
 [semver]: https://semver.org/
 


### PR DESCRIPTION
Resolve #62 

[Rendered](https://github.com/blas-lapack-rs/openblas-src/blob/changelog/CHANGELOG.md)

- 0.10.4
- 0.10.3
- 0.10.2
  - 0.10.0 and 0.10.1 are merged here because they has been yanked
- 0.9.0