### PR TITLE
Don't require the static runtime for openblas on Windows

### DIFF
--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -31,9 +31,7 @@ fn windows_gnu_system() {
 
 /// Use vcpkg for msvc "system" feature
 fn windows_msvc_system() {
-    if feature_enabled("static") {
-        env::set_var("CARGO_CFG_TARGET_FEATURE", "crt-static");
-    } else {
+    if !feature_enabled("static") {
         env::set_var("VCPKGRS_DYNAMIC", "1");
     }
     #[cfg(target_env = "msvc")]


### PR DESCRIPTION
As part of shipping openblas-src on Windows as part of a Python package, I would like to link dynamically to the CRT (this greatly reduces binary size). Currently I cannot do so because openblas-src forces linking to a static CRT.

I have made this patch as a workaround. I could also add a feature flag that only on Windows sets the static CRT if you would prefer, otherwise it can be left up to the parent crate what to do in a build.rs.