### PR TITLE
Add DYN_ARCH/USE_THREADS/USE_OPENMP features on linux

### DIFF
--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -394,9 +394,11 @@ impl Configure {
         }
         if self.use_thread {
             args.push("USE_THREAD=1".into());
+            args.push("NUM_THREADS=256".into());
         }
         if self.use_openmp {
             args.push("USE_OPENMP=1".into());
+            args.push("NUM_THREADS=256".into());
         }
         if matches!(self.interface, Interface::ILP64) {
             args.push("INTERFACE64=1".into());

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -31,6 +31,9 @@ cblas = []
 lapacke = []
 static = []
 system = []
+use_thread = []
+use_openmp = []
+dynamic_arch = []
 
 [dev-dependencies]
 libc = "0.2"

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -155,6 +155,15 @@ fn build() {
     cfg.compilers.hostcc = env::var("OPENBLAS_HOSTCC").ok();
     cfg.compilers.fc = env::var("OPENBLAS_FC").ok();
     cfg.compilers.ranlib = env::var("OPENBLAS_RANLIB").ok();
+    if feature_enabled("use_thread") {
+        cfg.use_thread = true;
+    }
+    if feature_enabled("use_openmp") {
+        cfg.use_openmp = true;
+    }
+    if feature_enabled("dynamic_arch") {
+        cfg.no_shared = true;
+    }
 
     let output = if feature_enabled("cache") {
         use std::hash::*;


### PR DESCRIPTION
These features were supported by the build crate, but not exposed.

I picked a default value for NUM_THREADS when USE_THREADS is set, as I see no way to have this configured through features.

Close #106