### PR TITLE
Add support for using a custom target under linux Fixes #18

### DIFF
--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -2,10 +2,11 @@
 
 use crate::{check::*, error::*};
 use std::{
-    fs,
+    fmt, fs,
     os::unix::io::*,
     path::*,
     process::{Command, Stdio},
+    str::FromStr,
 };
 use walkdir::WalkDir;
 
@@ -114,6 +115,99 @@ pub enum Target {
     ZARCH_GENERIC,
     Z13,
     Z14,
+}
+
+impl FromStr for Target {
+    type Err = ParseTargetError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let target = match s.to_ascii_lowercase().as_str() {
+            "p2" => Self::P2,
+            "katamai" => Self::KATMAI,
+            "coppermine" => Self::COPPERMINE,
+            "northwood" => Self::NORTHWOOD,
+            "prescott" => Self::PRESCOTT,
+            "banias" => Self::BANIAS,
+            "yonah" => Self::YONAH,
+            "core2" => Self::CORE2,
+            "penryn" => Self::PENRYN,
+            "dunnington" => Self::DUNNINGTON,
+            "nehalem" => Self::NEHALEM,
+            "sandybridge" => Self::SANDYBRIDGE,
+            "haswell" => Self::HASWELL,
+            "skylakex" => Self::SKYLAKEX,
+            "atom" => Self::ATOM,
+            "athlon" => Self::ATHLON,
+            "opteron" => Self::OPTERON,
+            "opteron_sse3" => Self::OPTERON_SSE3,
+            "barcelona" => Self::BARCELONA,
+            "shanghai" => Self::SHANGHAI,
+            "istanbul" => Self::ISTANBUL,
+            "bobcat" => Self::BOBCAT,
+            "bulldozer" => Self::BULLDOZER,
+            "piledriver" => Self::PILEDRIVER,
+            "steamroller" => Self::STEAMROLLER,
+            "excavator" => Self::EXCAVATOR,
+            "zen" => Self::ZEN,
+            "sse_generic" => Self::SSE_GENERIC,
+            "viac3" => Self::VIAC3,
+            "nano" => Self::NANO,
+            "power4" => Self::POWER4,
+            "power5" => Self::POWER5,
+            "power6" => Self::POWER6,
+            "power7" => Self::POWER7,
+            "power8" => Self::POWER8,
+            "power9" => Self::POWER9,
+            "ppcg4" => Self::PPCG4,
+            "ppc970" => Self::PPC970,
+            "ppc970mp" => Self::PPC970MP,
+            "ppc440" => Self::PPC440,
+            "ppc440fp2" => Self::PPC440FP2,
+            "cell" => Self::CELL,
+            "p5600" => Self::P5600,
+            "mips1004k" => Self::MIPS1004K,
+            "mips24k" => Self::MIPS24K,
+            "sicortex" => Self::SICORTEX,
+            "loongson3a" => Self::LOONGSON3A,
+            "loongson3b" => Self::LOONGSON3B,
+            "i6400" => Self::I6400,
+            "p6600" => Self::P6600,
+            "i6500" => Self::I6500,
+            "itanium2" => Self::ITANIUM2,
+            "sparc" => Self::SPARC,
+            "sparcv7" => Self::SPARCV7,
+            "cortexa15" => Self::CORTEXA15,
+            "cortexa9" => Self::CORTEXA9,
+            "armv7" => Self::ARMV7,
+            "armv6" => Self::ARMV6,
+            "armv5" => Self::ARMV5,
+            "armv8" => Self::ARMV8,
+            "cortexa53" => Self::CORTEXA53,
+            "cortexa57" => Self::CORTEXA57,
+            "cortexa72" => Self::CORTEXA72,
+            "cortexa73" => Self::CORTEXA73,
+            "neoversen1" => Self::NEOVERSEN1,
+            "emag8180" => Self::EMAG8180,
+            "falkor" => Self::FALKOR,
+            "thunderx" => Self::THUNDERX,
+            "thunderx2t99" => Self::THUNDERX2T99,
+            "tsv110" => Self::TSV110,
+            "zarch_generic" => Self::ZARCH_GENERIC,
+            "z13" => Self::Z13,
+            "z14" => Self::Z14,
+            _ => return Err(ParseTargetError::default()),
+        };
+        Ok(target)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParseTargetError;
+
+impl fmt::Display for ParseTargetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "provided string was not a valid target".fmt(f)
+    }
 }
 
 /// make option generator

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -104,6 +104,10 @@ fn build() {
     } else {
         cfg.no_static = true;
     }
+    cfg.target = match env::var("OPENBLAS_TARGET") {
+        Ok(target) => target.parse().ok(),
+        _ => None,
+    };
 
     let output = if feature_enabled("cache") {
         use std::{collections::hash_map::DefaultHasher, hash::*};


### PR DESCRIPTION
This allows the requested target to be specified by the environment variable `OPENBLAS_TARGET` under linux. This fixes #18 