### PR TITLE
Fix by cargo-clippy

### DIFF
--- a/.github/workflows/openblas-src.yml
+++ b/.github/workflows/openblas-src.yml
@@ -61,7 +61,7 @@ jobs:
       if: ${{ matrix.triple == 'x64-windows-static' }}
 
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,25 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  check-format:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check
+
+  clippy:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/cargo@v1
+      with:
+        command: clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: 'true'
     - uses: actions-rs/cargo@v1
       with:
         command: clippy

--- a/openblas-build/src/check.rs
+++ b/openblas-build/src/check.rs
@@ -38,7 +38,7 @@ impl LinkFlags {
     pub fn parse(line: &str) -> Result<Self, Error> {
         let mut search_paths = HashSet::new();
         let mut libs = HashSet::new();
-        for entry in line.split(" ") {
+        for entry in line.split(' ') {
             if entry.starts_with("-L") {
                 let path = PathBuf::from(entry.trim_start_matches("-L"));
                 if !path.exists() {
@@ -79,10 +79,10 @@ impl MakeConf {
         let buf = io::BufReader::new(f);
         for line in buf.lines() {
             let line = line.expect("Makefile.conf should not include non-UTF8 string");
-            if line.len() == 0 {
+            if line.is_empty() {
                 continue;
             }
-            let entry: Vec<_> = line.split("=").collect();
+            let entry: Vec<_> = line.split('=').collect();
             if entry.len() != 2 {
                 continue;
             }
@@ -133,7 +133,7 @@ impl LibInspect {
             .lines()
             .flat_map(|line| {
                 let line = line.expect("nm output should not include non-UTF8 output");
-                let entry: Vec<_> = line.trim().split(" ").collect();
+                let entry: Vec<_> = line.trim().split(' ').collect();
                 if entry.len() == 3 && entry[1] == "T" {
                     Some(entry[2].into())
                 } else {
@@ -173,7 +173,7 @@ impl LibInspect {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     pub fn has_lapack(&self) -> bool {
@@ -182,7 +182,7 @@ impl LibInspect {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     pub fn has_lapacke(&self) -> bool {
@@ -191,18 +191,18 @@ impl LibInspect {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     pub fn has_lib(&self, name: &str) -> bool {
         for lib in &self.libs {
-            if let Some(stem) = lib.split(".").next() {
+            if let Some(stem) = lib.split('.').next() {
                 if stem == format!("lib{}", name) {
                     return true;
                 }
             };
         }
-        return false;
+        false
     }
 }
 

--- a/openblas-build/src/check.rs
+++ b/openblas-build/src/check.rs
@@ -104,7 +104,6 @@ impl MakeConf {
 /// - Global "T" symbols in the text (code) section of library using `nm -g` external command.
 #[derive(Debug, Clone)]
 pub struct LibInspect {
-    path: PathBuf,
     pub libs: Vec<String>,
     pub symbols: Vec<String>,
 }
@@ -160,11 +159,7 @@ impl LibInspect {
             .collect();
         libs.sort();
 
-        Ok(LibInspect {
-            path: path.into(),
-            libs,
-            symbols,
-        })
+        Ok(LibInspect { libs, symbols })
     }
 
     pub fn has_cblas(&self) -> bool {

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -127,11 +127,11 @@ fn build() {
         // It makes users not to build OpenBLAS in every `cargo build`.
         let mut hasher = DefaultHasher::new();
         cfg.hash(&mut hasher);
-        let output = dirs::data_dir()
+
+        dirs::data_dir()
             .expect("Cannot get user's data directory")
             .join("openblas_build")
-            .join(format!("{:x}", hasher.finish()));
-        output
+            .join(format!("{:x}", hasher.finish()))
     } else {
         PathBuf::from(env::var("OUT_DIR").unwrap())
     };


### PR DESCRIPTION
Minor maintenance.

- `macos-10.5` has been deprecated, switch to `macos-11`
- Add CI check for clippy and rustfmt