### PR TITLE
Expand tar.gz on `OUT_DIR`

### DIFF
--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -22,18 +22,6 @@ categories = ["science"]
 keywords = ["linear-algebra"]
 build = "build.rs"
 links = "openblas"
-exclude = [
-    "source/benchmark/*",
-    "source/ctest/*",
-    "source/lapack-netlib/BLAS/TESTING/*",
-    "source/lapack-netlib/CBLAS/testing/*",
-    "source/lapack-netlib/TESTING/*.in",
-    "source/lapack-netlib/TESTING/EIG/*",
-    "source/lapack-netlib/TESTING/LIN/*",
-    "source/reference/*",
-    "source/test/*",
-    "source/utest/*",
-]
 
 [features]
 default = ["cblas", "lapacke"]

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -160,13 +160,13 @@ fn build() {
         );
     }
 
-    let source =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("OpenBLAS-{}", OPENBLAS_VERSION));
+    let source = output.join(format!("OpenBLAS-{}", OPENBLAS_VERSION));
     if !source.exists() {
+        let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         Command::new("tar")
             .arg("xf")
-            .arg(format!("OpenBLAS-{}.tar.gz", OPENBLAS_VERSION))
-            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .arg(crate_root.join(format!("OpenBLAS-{}.tar.gz", OPENBLAS_VERSION)))
+            .current_dir(&output)
             .status()
             .expect("tar command not found");
     }


### PR DESCRIPTION
It is expanded on `CARGO_MANIFEST_DIR`, but `build.rs` should not modify source directory. It will be warned by `cargo-release`