### PR TITLE
Use native-tls/native-certs features of ureq crate

### DIFF
--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -11,22 +11,15 @@ repository = "https://github.com/blas-lapack-rs/openblas-src"
 readme = "../README.md"
 exclude = ["test_build/"]
 
-[features]
-default = ["tls"]
-
-tls = ["ureq/tls", "ureq/gzip"]
-native-certs = [
-    "native-tls",
-    "ureq/native-certs",
-    "ureq/native-tls",
-    "ureq/gzip",
-]
-
 [dependencies]
 anyhow = "1.0.68"
 flate2 = "1.0.25"
 tar = "0.4.38"
 thiserror = "1.0.22"
-ureq = { version = "2.5.0", default-features = false }
-native-tls = { version = "0.2.11", optional = true }
+ureq = { version = "2.5.0", default-features = false, features = [
+    "native-certs",
+    "native-tls",
+    "gzip",
+] }
+native-tls = { version = "0.2.11" }
 walkdir = "2.3.1"

--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -3,16 +3,23 @@ name = "openblas-build"
 version = "0.10.7"
 license = "Apache-2.0/MIT"
 edition = "2018"
-authors = [
-    "Toshiki Teramura <toshiki.teramura@gmail.com>",
-]
+authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 description = "The package provides a build helper for OpenBLAS."
 documentation = "https://docs.rs/openblas-build"
 homepage = "https://github.com/blas-lapack-rs/openblas-src"
 repository = "https://github.com/blas-lapack-rs/openblas-src"
-readme  = "../README.md"
-exclude = [
-    "test_build/",
+readme = "../README.md"
+exclude = ["test_build/"]
+
+[features]
+default = ["tls"]
+
+tls = ["ureq/tls", "ureq/gzip"]
+native-certs = [
+    "native-tls",
+    "ureq/native-certs",
+    "ureq/native-tls",
+    "ureq/gzip",
 ]
 
 [dependencies]
@@ -20,5 +27,6 @@ anyhow = "1.0.68"
 flate2 = "1.0.25"
 tar = "0.4.38"
 thiserror = "1.0.22"
-ureq = "2.5.0"
+ureq = { version = "2.5.0", default-features = false }
+native-tls = { version = "0.2.11", optional = true }
 walkdir = "2.3.1"

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -25,16 +25,10 @@ pub fn download(out_dir: &Path) -> Result<PathBuf> {
     Ok(dest)
 }
 
-#[cfg(feature = "native-tls")]
 fn get_agent() -> ureq::Agent {
     ureq::AgentBuilder::new()
         .tls_connector(std::sync::Arc::new(
             native_tls::TlsConnector::new().expect("failed to create TLS connector"),
         ))
         .build()
-}
-
-#[cfg(not(feature = "native-tls"))]
-fn get_agent() -> ureq::Agent {
-    ureq::agent()
 }

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -13,11 +13,28 @@ pub fn openblas_source_url() -> String {
 pub fn download(out_dir: &Path) -> Result<PathBuf> {
     let dest = out_dir.join(format!("OpenBLAS-{}", OPENBLAS_VERSION));
     if !dest.exists() {
-        let buf = ureq::get(&openblas_source_url()).call()?.into_reader();
+        let buf = get_agent()
+            .get(&openblas_source_url())
+            .call()?
+            .into_reader();
         let gz_stream = flate2::read::GzDecoder::new(buf);
         let mut ar = tar::Archive::new(gz_stream);
         ar.unpack(out_dir)?;
         assert!(dest.exists());
     }
     Ok(dest)
+}
+
+#[cfg(feature = "native-tls")]
+fn get_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .tls_connector(std::sync::Arc::new(
+            native_tls::TlsConnector::new().expect("failed to create TLS connector"),
+        ))
+        .build()
+}
+
+#[cfg(not(feature = "native-tls"))]
+fn get_agent() -> ureq::Agent {
+    ureq::agent()
 }

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -24,22 +24,20 @@ build = "build.rs"
 links = "openblas"
 
 [features]
-default = ["cblas", "lapacke", "tls"]
+default = ["cblas", "lapacke"]
 
 cache = []
 cblas = []
 lapacke = []
 static = []
 system = []
-tls = ["openblas-build/tls"]
-native-certs = ["openblas-build/native-certs"]
 
 [dev-dependencies]
 libc = "0.2"
 
 [build-dependencies]
 dirs = "3.0.1"
-openblas-build = { version = "0.10.7", path = "../openblas-build", default-features = false }
+openblas-build = { version = "0.10.7", path = "../openblas-build" }
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -24,20 +24,22 @@ build = "build.rs"
 links = "openblas"
 
 [features]
-default = ["cblas", "lapacke"]
+default = ["cblas", "lapacke", "tls"]
 
 cache = []
 cblas = []
 lapacke = []
 static = []
 system = []
+tls = ["openblas-build/tls"]
+native-certs = ["openblas-build/native-certs"]
 
 [dev-dependencies]
 libc = "0.2"
 
 [build-dependencies]
 dirs = "3.0.1"
-openblas-build = { version = "0.10.7", path = "../openblas-build" }
+openblas-build = { version = "0.10.7", path = "../openblas-build", default-features = false }
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
Hello!

We use this crate on one of our projects, once we bumped it to version 0.10.7, we started getting failures for the license checks in cargo-deny, since openblas-build now uses `ureq` for [downloading the openblas source](https://github.com/blas-lapack-rs/openblas-src/blob/master/openblas-build/src/download.rs#L16), which brings in a dependency with a MPL-2.0 license to the Cargo.lock file (it has been brought up in ureq repo as well https://github.com/algesten/ureq/issues/478). 

`ureq` does have some feature flags that provide the possibility to use native-tls, the lib doesn't implement the default tls config when using `native-tls` feature flag (https://github.com/algesten/ureq/blob/main/src/lib.rs#L377-L397), but it allows to setup an agent explicitly by providing the tls config (as it is done in this test https://github.com/algesten/ureq/blob/main/src/lib.rs#L583-L595).
There was a proposal for adding feature flag in `ureq` that includes `rustls` with the `native-certs` flag so that the default agent can work with the `native-certs` (https://github.com/algesten/ureq/pull/482), but it was rejected, so currently it is not possible to just tweak the feature flags on `ureq` and exclude the unwanted sub-dependencies. 

The idea of this PR is to add feature flags to `openblas-src` and `openblas-build` that allows users to choose which tls config they want to use. This PR introduces 2 feature flags (`tls` which includes the default tls that `ureq` uses, and `native-certs` which uses `native-tls` and `native-certs` feature flags in `ureq`).
The default flags are set to use the `tls` feature flag, but worth to note is that this would probably be a breaking change when the default features are disabled and neither of these flags are enabled.

Any thoughts on this?
I look forward to you feedback!