### PR TITLE
respect OPENBLAS_{{CC, FC, HOSTCC}} env vars on linux

### DIFF
--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -332,7 +332,7 @@ pub struct Deliverables {
 impl Configure {
     fn cross_compile_args(&self) -> Result<Vec<String>, Error> {
         let mut args = Vec::new();
-        for name in &vec!["CC", "FC", "HOSTCC"] {
+        for name in ["CC", "FC", "HOSTCC"] {
             if let Ok(value) = std::env::var(format!("OPENBLAS_{}", name)) {
                 args.push(format!("{}={}", name, value));
                 eprintln!("{}={}", name, value);
@@ -343,6 +343,13 @@ impl Configure {
         // for successful compile all 3 env-vars must be set
         if !args.is_empty() && args.len() != 3 {
             return Err(Error::MissingCrossCompileInfo);
+        }
+        // optional flags
+        for name in ["RANLIB"] {
+            if let Ok(value) = std::env::var(format!("OPENBLAS_{}", name)) {
+                args.push(format!("{}={}", name, value));
+                eprintln!("{}={}", name, value);
+            }
         }
         Ok(args)
     }

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -330,6 +330,23 @@ pub struct Deliverables {
 }
 
 impl Configure {
+    fn cross_compile_args(&self) -> Result<Vec<String>, Error> {
+        let mut args = Vec::new();
+        for name in &vec!["CC", "FC", "HOSTCC"] {
+            if let Ok(value) = std::env::var(format!("OPENBLAS_{}", name)) {
+                args.push(format!("{}={}", name, value));
+                eprintln!("{}={}", name, value);
+            } else {
+                eprintln!("not found {}", name);
+            }
+        }
+        // for successful compile all 3 env-vars must be set
+        if !args.is_empty() && args.len() != 3 {
+            return Err(Error::MissingCrossCompileInfo);
+        }
+        Ok(args)
+    }
+
     fn make_args(&self) -> Vec<String> {
         let mut args = Vec::new();
         if self.no_static {
@@ -467,6 +484,7 @@ impl Configure {
             .stdout(out)
             .stderr(err)
             .args(&self.make_args())
+            .args(&self.cross_compile_args()?)
             .args(["all"])
             .env_remove("TARGET")
             .check_call()

--- a/openblas-build/src/error.rs
+++ b/openblas-build/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     #[error("Target {} is unsupported", target)]
     UnsupportedTarget { target: String },
 
+    #[error("Insufficient cross compile information, need all of OPENBLAS_{{CC, FC, HOSTCC}}")]
+    MissingCrossCompileInfo,
+
     #[error("Other IO errors: {0:?}")]
     IOError(#[from] io::Error),
 }


### PR DESCRIPTION
this should fix issue #101 

together with PR rust-ndarray/ndarray-linalg#354
I can run this successfully on a x86_64 machine to cross compile for a Raspi 4

```shell
export OPENBLAS_CC=aarch64-linux-gnu-gcc
export OPENBLAS_FC=aarch64-linux-gnu-gfortran
export OPENBLAS_HOSTCC=gcc
export OPENBLAS_TARGET=ARMV8 # CORTEXA72
cargo build --release --target=aarch64-unknown-linux-gnu
```