### PR TITLE
bump package version + bump openblas version to 0.3.22 so that building on avx512 platforms pass

### DIFF
--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openblas-build"
-version = "0.10.8"
+version = "0.10.9"
 license = "Apache-2.0/MIT"
 edition = "2018"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
-const OPENBLAS_VERSION: &str = "0.3.21";
+const OPENBLAS_VERSION: &str = "0.3.22";
 
 pub fn openblas_source_url() -> String {
     format!(

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openblas-src"
-version = "0.10.8"
+version = "0.10.9"
 license = "Apache-2.0/MIT"
 edition = "2018"
 authors = [
@@ -37,7 +37,7 @@ libc = "0.2"
 
 [build-dependencies]
 dirs = "3.0.1"
-openblas-build = { version = "0.10.8", path = "../openblas-build" }
+openblas-build = { version = "0.10.9", path = "../openblas-build" }
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
CPU: 7950X
OS: Ubuntu 22.04

build was failing on:
```
  In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/immintrin.h:49,
                   from ../kernel/x86_64/../arm/../simd/intrin.h:51,
                   from ../kernel/x86_64/../arm/sum.c:33:
  /usr/lib/gcc/x86_64-linux-gnu/11/include/avx512fintrin.h:4517:1: error: inlining failed in call to ‘always_inline’ ‘_mm512_shuffle_f32x4’: target specific option mismatch
   4517 | _mm512_shuffle_f32x4 (__m512 __A, __m512 __B, const int __imm)
        | ^~~~~~~~~~~~~~~~~~~~
  In file included from ../kernel/x86_64/../arm/../simd/intrin.h:61,
                   from ../kernel/x86_64/../arm/sum.c:33:
  ../kernel/x86_64/../arm/../simd/intrin_avx512.h:29:18: note: called from here
     29 |     __m512 h32 = _mm512_shuffle_f32x4(sum32, sum32, _MM_SHUFFLE(1, 0, 3, 2));
        |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/immintrin.h:49,
                   from ../kernel/x86_64/../arm/../simd/intrin.h:51,
                   from ../kernel/x86_64/../arm/sum.c:33:
  /usr/lib/gcc/x86_64-linux-gnu/11/include/avx512fintrin.h:12520:1: error: inlining failed in call to ‘always_inline’ ‘_mm512_add_ps’: target specific option mismatch
  12520 | _mm512_add_ps (__m512 __A, __m512 __B)
        | ^~~~~~~~~~~~~
  In file included from ../kernel/x86_64/../arm/../simd/intrin.h:61,
                   from ../kernel/x86_64/../arm/sum.c:33:
  ../kernel/x86_64/../arm/../simd/intrin_avx512.h:28:20: note: called from here
     28 |     __m512 sum32 = _mm512_add_ps(a, h64);
        |                    ^~~~~~~~~~~~~~~~~~~~~
  In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/immintrin.h:49,
                   from ../kernel/x86_64/../arm/../simd/intrin.h:51,
                   from ../kernel/x86_64/../arm/sum.c:33:
  /usr/lib/gcc/x86_64-linux-gnu/11/include/avx512fintrin.h:4517:1: error: inlining failed in call to ‘always_inline’ ‘_mm512_shuffle_f32x4’: target specific option mismatch
   4517 | _mm512_shuffle_f32x4 (__m512 __A, __m512 __B, const int __imm)
        | ^~~~~~~~~~~~~~~~~~~~
  In file included from ../kernel/x86_64/../arm/../simd/intrin.h:61,
                   from ../kernel/x86_64/../arm/sum.c:33:
  ../kernel/x86_64/../arm/../simd/intrin_avx512.h:27:18: note: called from here
     27 |     __m512 h64 = _mm512_shuffle_f32x4(a, a, _MM_SHUFFLE(3, 2, 3, 2));
        |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  make[1]: *** [Makefile.L1:699: ssum_k.o] Error 1
  make[1]: *** Waiting for unfinished jobs....
  ../kernel/x86_64/omatcopy_rt.c: In function ‘somatcopy_k_rt’:
  ../kernel/x86_64/omatcopy_rt.c:130:3: warning: ‘dst_tmp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    130 |   __asm__ __volatile__(\
        |   ^~~~~~~
  ../kernel/x86_64/omatcopy_rt.c:145:22: note: ‘dst_tmp’ was declared here
    145 |   float *src, *dst, *dst_tmp, *src_base, *dst_base;
        |                      ^~~~~~~
  make: *** [Makefile:177: libs] Error 1
```

I checked out https://github.com/xianyi/OpenBLAS on `v0.3.21` and got the same error with `make`. Once I bumped to `v0.3.22` the build passes. This smell like a bug in OpenBLAS. I'll dig around and see if there was an issue opened on this