### PR TITLE
OpenBLAS v0.3.25 & Extended Target Support & Build Fixes

### DIFF
--- a/.github/workflows/openblas-build.yml
+++ b/.github/workflows/openblas-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -460,7 +460,7 @@ impl Configure {
             .stdout(out)
             .stderr(err)
             .args(&self.make_args())
-            .args(["libs", "netlib", "shared"])
+            .args(["all"])
             .env_remove("TARGET")
             .check_call()
         {

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -359,6 +359,13 @@ impl Configure {
         if let Some(target) = self.target.as_ref() {
             args.push(format!("TARGET={:?}", target))
         }
+
+        for name in ["CC", "FC", "HOSTCC"] {
+            if let Ok(value) = std::env::var(format!("OPENBLAS_{}", name)) {
+                args.push(format!("{}={}", name, value));
+            }
+        }
+
         args
     }
 

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -31,6 +31,8 @@ pub enum Target {
     HASWELL,
     SKYLAKEX,
     ATOM,
+    COOPERLAKE,
+    SAPPHIRERAPIDS,
 
     // X86/X86_64 AMD
     ATHLON,
@@ -58,6 +60,7 @@ pub enum Target {
     POWER7,
     POWER8,
     POWER9,
+    POWER10,
     PPCG4,
     PPC970,
     PPC970MP,
@@ -71,6 +74,7 @@ pub enum Target {
     MIPS24K,
 
     // MIPS64
+    MIPS64_GENERIC,
     SICORTEX,
     LOONGSON3A,
     LOONGSON3B,
@@ -98,17 +102,46 @@ pub enum Target {
     CORTEXA57,
     CORTEXA72,
     CORTEXA73,
+    CORTEXA510,
+    CORTEXA710,
+    CORTEXX1,
+    CORTEXX2,
     NEOVERSEN1,
+    NEOVERSEV1,
+    NEOVERSEN2,
+    CORTEXA55,
     EMAG8180,
     FALKOR,
     THUNDERX,
     THUNDERX2T99,
     TSV110,
+    THUNDERX3T110,
+    VORTEX,
+    A64FX,
+    ARMV8SVE,
+    FT2000,
 
     // System Z
     ZARCH_GENERIC,
     Z13,
     Z14,
+
+    // RISC-V 64:
+    RISCV64_GENERIC,
+    C910V,
+
+    // LOONGARCH64:
+    LOONGSONGENERIC,
+    LOONGSON3R5,
+    LOONGSON2K1000,
+
+    // Elbrus E2000:
+    E2K,
+
+    // Alpha
+    EV4,
+    EV5,
+    EV6,
 }
 
 impl FromStr for Target {
@@ -132,6 +165,8 @@ impl FromStr for Target {
             "haswell" => Self::HASWELL,
             "skylakex" => Self::SKYLAKEX,
             "atom" => Self::ATOM,
+            "cooperlake" => Self::COOPERLAKE,
+            "sapphirerapids" => Self::SAPPHIRERAPIDS,
 
             // X86/X86_64 AMD
             "athlon" => Self::ATHLON,
@@ -159,6 +194,7 @@ impl FromStr for Target {
             "power7" => Self::POWER7,
             "power8" => Self::POWER8,
             "power9" => Self::POWER9,
+            "power10" => Self::POWER10,
             "ppcg4" => Self::PPCG4,
             "ppc970" => Self::PPC970,
             "ppc970mp" => Self::PPC970MP,
@@ -172,6 +208,7 @@ impl FromStr for Target {
             "mips24k" => Self::MIPS24K,
 
             // MIPS64
+            "mips64_generic" => Self::MIPS64_GENERIC,
             "sicortex" => Self::SICORTEX,
             "loongson3a" => Self::LOONGSON3A,
             "loongson3b" => Self::LOONGSON3B,
@@ -199,17 +236,46 @@ impl FromStr for Target {
             "cortexa57" => Self::CORTEXA57,
             "cortexa72" => Self::CORTEXA72,
             "cortexa73" => Self::CORTEXA73,
+            "cortexa510" => Self::CORTEXA510,
+            "cortexa710" => Self::CORTEXA710,
+            "cortexx1" => Self::CORTEXX1,
+            "cortexx2" => Self::CORTEXX2,
             "neoversen1" => Self::NEOVERSEN1,
+            "neoversev1" => Self::NEOVERSEV1,
+            "neoversen2" => Self::NEOVERSEN2,
+            "cortexa55" => Self::CORTEXA55,
             "emag8180" => Self::EMAG8180,
             "falkor" => Self::FALKOR,
             "thunderx" => Self::THUNDERX,
             "thunderx2t99" => Self::THUNDERX2T99,
             "tsv110" => Self::TSV110,
+            "thunderx3t110" => Self::THUNDERX3T110,
+            "vortex" => Self::VORTEX,
+            "a64fx" => Self::A64FX,
+            "armv8sve" => Self::ARMV8SVE,
+            "ft2000" => Self::FT2000,
 
             // System Z
             "zarch_generic" => Self::ZARCH_GENERIC,
             "z13" => Self::Z13,
             "z14" => Self::Z14,
+
+            // RISC-V 64:
+            "riscv64_generic" => Self::RISCV64_GENERIC,
+            "c910v" => Self::C910V,
+
+            // LOONGARCH64:
+            "loongsongeneric" => Self::LOONGSONGENERIC,
+            "loongson3r5" => Self::LOONGSON3R5,
+            "loongson2k1000" => Self::LOONGSON2K1000,
+
+            // Elbrus E2000:
+            "e2k" => Self::E2K,
+
+            // Alpha
+            "ev4" => Self::EV4,
+            "ev5" => Self::EV5,
+            "ev6" => Self::EV6,
 
             _ => {
                 return Err(Error::UnsupportedTarget {

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
-const OPENBLAS_VERSION: &str = "0.3.21";
+const OPENBLAS_VERSION: &str = "0.3.25";
 
 pub fn openblas_source_url() -> String {
     format!(

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -202,7 +202,7 @@ fn build() {
 
     let output = PathBuf::from(env::var("OUT_DIR").unwrap().replace(r"\", "/"));
     let mut make = Command::new("make");
-    make.args(&["libs", "netlib", "shared"])
+    make.args(&["all"])
         .arg(format!("BINARY={}", binary()))
         .arg(format!(
             "{}_CBLAS=1",


### PR DESCRIPTION
This PR incorporates several updates and fixes:

1. **OpenBLAS Upgrade**: OpenBLAS has been updated to version 0.3.25.

2. **Extended Target Support**: This update also includes expanded support for several additional targets across various platforms:

    **X86/X86_64 Intel**:
    - COOPERLAKE
    - SAPPHIRERAPIDS

    **Power**:
    - POWER10

    **MIPS64**:
    - MIPS64_GENERIC

    **ARM64**:
    - CORTEXA510
    - CORTEXA710
    - CORTEXX1
    - CORTEXX2
    - NEOVERSEV1
    - NEOVERSEN2
    - CORTEXA55
    - THUNDERX3T110
    - VORTEX
    - A64FX
    - ARMV8SVE
    - FT2000

    **RISC-V 64**:
    - RISCV64_GENERIC
    - C910V

    **LOONGARCH64**:
    - LOONGSONGENERIC
    - LOONGSON3R5
    - LOONGSON2K1000

    **Elbrus E2000**:
    - E2K

    **Alpha**:
    - EV4
    - EV5
    - EV6

3. **Parallel Build Fix for OpenBLAS**: Further details on this issue can be found at https://github.com/OpenMathLib/OpenBLAS/pull/3983#issue-1649371764.

4. **Bug Fix**:  https://github.com/blas-lapack-rs/openblas-src/issues/101#issue-1692678925

If necessary, I can partition these changes into separate pull requests for easier review and management. Please let me know if you'd prefer this approach.