### PR TITLE
Fix failing docs build on crates.io

### DIFF
--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -76,6 +76,9 @@ fn macos_system() {
 }
 
 fn main() {
+    if !env::var("DOCS_RS").is_ok() {
+        return;
+    }
     let link_kind = if feature_enabled("static") {
         "static"
     } else {


### PR DESCRIPTION
Suppress build on crates.io by checking DOCS_RS to circumvent failing of building docs without internet connection as is the situation on crates.io