### PR TITLE
Use macos-14 instance for CI

### DIFF
--- a/.github/workflows/openblas-src.yml
+++ b/.github/workflows/openblas-src.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ matrix.triple == 'x64-windows-static' }}
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/