### PR TITLE
Add ARM cross-compilation to CI (#113)

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,0 +1,25 @@
+on: [push]
+
+name: Cross CI
+
+jobs:
+  cross:
+    name: Rust ${{matrix.target}}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{matrix.target}}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target ${{matrix.target}}

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,12 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update && apt-get --assume-yes install gfortran-aarch64-linux-gnu gcc-aarch64-linux-gnu libssl-dev:$CROSS_DEB_ARCH libssl-dev"
+]
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = [
+    "OPENBLAS_CC=aarch64-linux-gnu-gcc",
+    "OPENBLAS_HOSTCC=gcc",
+    "OPENBLAS_FC=aarch64-linux-gnu-gfortran",
+    "OPENBLAS_TARGET=NEOVERSEN1"
+]


### PR DESCRIPTION
This PR introduces ARM cross-compilation into the continuous integration pipeline.  It is presumed that, if this particular CI passes, all the available targets for cross-compilation should work. 

**Observation**
For cross-compilation within the Docker image, we need to install `libssl-dev` for both the host and the intended target.  `libssl` is only required by `openblas-build` for its `native-ssl` dependency. However, `openblas-build` is only needed to download and build `OpenBLAS`, and might not be required to cross-compile itself.