### PR TITLE
use pkg-config if available

### DIFF
--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -36,6 +36,7 @@ system = []
 libc = "0.2"
 
 [build-dependencies]
+pkg-config = "^0.3.30"
 dirs = "3.0.1"
 openblas-build = { version = "0.10.9", path = "../openblas-build" }
 

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -82,6 +82,12 @@ fn main() {
         "dylib"
     };
     if feature_enabled("system") {
+        if link_kind == "dylib" && pkg_config::probe_library("openblas").is_ok() {
+            // pkg-config does everything, including output for cargo: we can
+            // jump out early.
+            return;
+        }
+
         if cfg!(target_os = "windows") {
             if cfg!(target_env = "gnu") {
                 windows_gnu_system();


### PR DESCRIPTION
At present, this code (when linking against system) requires homebrew on MacOS, but not all MacOS systems have homebrew. If pkg-config lets one link to openblas, use it.