### PR TITLE
Take proxy environment variables into account

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ They can be set as environment variables for `cargo build` using the `OPENBLAS_`
 prefix as follows: `OPENBLAS_CC`, `OPENBLAS_FC`, `OPENBLAS_HOSTCC`, and
 `OPENBLAS_TARGET`.
 
+## Proxy issues
+
+The `openblas-src` crate will detect and use proxy settings from your environment variables, such as `http_proxy` and `https_proxy` to download necessary dependencies. 
+
 ## Contribution
 
 Your contribution is highly appreciated. Do not hesitate to open an issue or a

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -30,5 +30,6 @@ fn get_agent() -> ureq::Agent {
         .tls_connector(std::sync::Arc::new(
             native_tls::TlsConnector::new().expect("failed to create TLS connector"),
         ))
+        .try_proxy_from_env(true)
         .build()
 }


### PR DESCRIPTION
Building fails when behind a proxy because the tarball cannot be downloaded. This easy fix lets ureq look at the http_proxy environment variable.