### PR TITLE
Fix MSRV

### DIFF
--- a/.github/workflows/openblas-build.yml
+++ b/.github/workflows/openblas-build.yml
@@ -22,8 +22,6 @@ jobs:
           - build_no_lapacke
           - build_no_shared
           - build_openmp
-    container:
-      image: rust
     env:
       RUST_BACKTRACE: 1
     steps:
@@ -32,8 +30,8 @@ jobs:
           submodules: "recursive"
       - name: Install gfortran by apt
         run: |
-          apt update
-          apt install -y gfortran
+          sudo apt update
+          sudo apt install -y gfortran
       - name: Common minor tests
         run: cargo test  --manifest-path=openblas-build/Cargo.toml
       - name: Build test

--- a/.github/workflows/openblas-src.yml
+++ b/.github/workflows/openblas-src.yml
@@ -109,7 +109,7 @@ jobs:
   
   cross:
     name: ${{matrix.target}} (${{matrix.feature}})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -132,3 +132,16 @@ jobs:
           tool: cross
       - name: Test features=${{ matrix.feature }}
         run: cross test --target ${{matrix.target}} --features=${{ matrix.feature }} --manifest-path=openblas-src/Cargo.toml
+  msrv-test:
+    name: MSRV test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OpenBLAS by apt
+        run: |
+          apt update
+          apt install -y libopenblas-dev
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@1.71
+      - name: cargo test
+        run: cargo check --manifest-path=openblas-src/Cargo.toml --features=system

--- a/.github/workflows/openblas-src.yml
+++ b/.github/workflows/openblas-src.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   windows-msvc:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -82,8 +82,6 @@ jobs:
 
   x86_64-unknown-linux-gnu:
     runs-on: ubuntu-22.04
-    container:
-      image: rust
     strategy:
       fail-fast: false
       matrix:
@@ -97,12 +95,12 @@ jobs:
           submodules: "recursive"
       - name: Install gfortran by apt
         run: |
-          apt update
-          apt install -y gfortran
+          sudo apt update
+          sudo apt install -y gfortran
       - name: Install OpenBLAS by apt
         run: |
-          apt update
-          apt install -y libopenblas-dev
+          sudo apt update
+          sudo apt install -y libopenblas-dev
         if: ${{ contains(matrix.feature, 'system') }}
       - name: Test features=${{ matrix.feature }}
         run: cargo test --features=${{ matrix.feature }} --manifest-path=openblas-src/Cargo.toml
@@ -139,8 +137,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install OpenBLAS by apt
         run: |
-          apt update
-          apt install -y libopenblas-dev
+          sudo apt update
+          sudo apt install -y libopenblas-dev
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@1.71
       - name: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
   "openblas-src",
   "openblas-build",
 ]
+
+[workspace.package]
+rust-version = "1.71.1"

--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/blas-lapack-rs/openblas-src"
 repository = "https://github.com/blas-lapack-rs/openblas-src"
 readme = "../README.md"
 exclude = ["test_build/"]
+rust-version = "1.71.1"
 
 [dependencies]
 anyhow = "1.0.68"
@@ -17,7 +18,7 @@ cc = "1.0"
 flate2 = "1.0.25"
 tar = "0.4.38"
 thiserror = "2.0"
-ureq = { version = "2.5.0", default-features = false, features = [
+ureq = { version = "2.8", default-features = false, features = [
     "native-certs",
     "native-tls",
     "gzip",

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["science"]
 keywords = ["linear-algebra"]
 build = "build.rs"
 links = "openblas"
+rust-version = "1.71.1"
 
 [features]
 default = ["cblas", "lapacke"]

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -157,7 +157,10 @@ fn build() {
     cfg.compilers.ranlib = env::var("OPENBLAS_RANLIB").ok();
 
     let output = if feature_enabled("cache") {
-        use std::hash::*;
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash, Hasher},
+        };
         // Build OpenBLAS on user's data directory.
         // See https://docs.rs/dirs/5.0.1/dirs/fn.data_dir.html
         //


### PR DESCRIPTION
Add `std::collections::hash_map::DefaultHasher` to `build.rs` because there's no DefaultHasher in std::hash before rustc 1.76.
Pin MSRV to 1.71.1 since the `ureq` require `1.71.1` now.
Related to #133 