### PR TITLE
Remove duplicated link instructions

### DIFF
--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -111,7 +111,6 @@ fn main() {
         if cfg!(target_os = "macos") {
             macos_system();
         }
-        println!("cargo:rustc-link-lib={}=openblas", link_kind);
     } else {
         if cfg!(target_env = "msvc") {
             panic!(


### PR DESCRIPTION
When the `system` feature is enabled, the same link instruction is being output twice (once from the code removed in this PR and once again at the end of the main function).

Although having multiple outputs does not cause functional issues, I believe it’s better to remove the duplication for future maintainability.