### PR TITLE
Export path to libopenblas for external usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ the variables that are renamed:
 | HOSTCC            | OPENBLAS_HOSTCC       |
 | RANLIB            | OPENBLAS_RANLIB       |
 
+### Variables emitted by build.rs
+
+This crate exports the following environment variables for downstream crates’ build scripts:
+
+- `DEP_OPENBLAS_INCLUDE`: Absolute path to the OpenBLAS C headers directory (e.g., a directory that
+      contains `cblas.h`, `lapacke.h` when enabled).
+- `DEP_OPENBLAS_LIBRARY`: Absolute path to the produced OpenBLAS library artifact (e.g., `libopenblas.a`,
+      `libopenblas.so`, `openblas.lib`, depending on platform/linking).
+
 ## Cross-compile
 
 Apart from providing the `--target` option to `cargo build`, one also has to

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -28,6 +28,15 @@ fn feature_enabled(feature: &str) -> bool {
 ///   - msys2 `/` is `C:\msys64\` in Windows by default install
 ///   - It can be convert using `cygpath` command
 fn windows_gnu_system() {
+    let include_path = String::from_utf8(
+        Command::new("cygpath")
+            .arg("-w")
+            .arg("/mingw64/include")
+            .output()
+            .expect("Failed to exec cygpath")
+            .stdout,
+    )
+    .expect("cygpath output includes non UTF-8 string");
     let lib_path = String::from_utf8(
         Command::new("cygpath")
             .arg("-w")
@@ -42,6 +51,8 @@ fn windows_gnu_system() {
     )
     .expect("cygpath output includes non UTF-8 string");
     println!("cargo:rustc-link-search={}", lib_path);
+    println!("cargo:INCLUDE={}", include_path);
+    println!("cargo:LIBRARY={}", lib_path);
 }
 
 /// Use vcpkg for msvc "system" feature
@@ -75,6 +86,8 @@ fn macos_system() {
 
     println!("cargo:rustc-link-search={}/lib", openblas.display());
     println!("cargo:rustc-link-search={}/lib", libomp.display());
+    println!("cargo:INCLUDE={}", openblas.join("include").display());
+    println!("cargo:LIBRARY={}", openblas.join("lib").display());
 }
 
 fn main() {
@@ -219,6 +232,8 @@ fn build() {
     };
 
     println!("cargo:rustc-link-search={}", source.display());
+    println!("cargo:INCLUDE={}", source.display());
+    println!("cargo:LIBRARY={}", source.display());
     for search_path in &make_conf.c_extra_libs.search_paths {
         println!("cargo:rustc-link-search={}", search_path.display());
     }


### PR DESCRIPTION
This change exports the directory where `libopenblas` is located.

Having this information available is especially useful when compiling Rust bindings for other C/C++ libraries that depend on OpenBLAS. In such cases, knowing the exact location of `libopenblas` provided by this crate helps ensure a smoother build process and reduces the need for additional configuration.
