### PR TITLE
Plumb DYNAMIC_ARCH, USE_THREAD, and USE_OPENMP through the build crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Unreleased](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.15...master)
 -----------
+
+## What's Changed
+* Plumb `DYNAMIC_ARCH` through `openblas-build::Configure` (previously dead field) and expose `DYNAMIC_ARCH`, `USE_THREAD`, and `USE_OPENMP` via `OPENBLAS_DYNAMIC_ARCH`, `OPENBLAS_USE_THREAD`, and `OPENBLAS_USE_OPENMP` env vars in `openblas-src`. Fixes [#106](https://github.com/blas-lapack-rs/openblas-src/issues/106) and picks up the work abandoned in [#72](https://github.com/blas-lapack-rs/openblas-src/pull/72).
+
 [0.10.15 - 2026-03-24](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.14...v0.10.15)
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -----------
 
 ## What's Changed
-* Plumb `DYNAMIC_ARCH` through `openblas-build::Configure` (previously dead field) and expose `DYNAMIC_ARCH`, `USE_THREAD`, and `USE_OPENMP` via `OPENBLAS_DYNAMIC_ARCH`, `OPENBLAS_USE_THREAD`, and `OPENBLAS_USE_OPENMP` env vars in `openblas-src`. Fixes [#106](https://github.com/blas-lapack-rs/openblas-src/issues/106) and picks up the work abandoned in [#72](https://github.com/blas-lapack-rs/openblas-src/pull/72).
+* Plumb `DYNAMIC_ARCH` through `openblas-build::Configure` (previously dead field) and expose the threading-related build flags `DYNAMIC_ARCH`, `USE_THREAD`, `USE_OPENMP`, `USE_LOCKING`, `NUM_THREADS`, and `NUM_PARALLEL` via the corresponding `OPENBLAS_*` env vars in `openblas-src`. Fixes [#106](https://github.com/blas-lapack-rs/openblas-src/issues/106) and picks up the work abandoned in [#72](https://github.com/blas-lapack-rs/openblas-src/pull/72).
 
 [0.10.15 - 2026-03-24](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.14...v0.10.15)
 -----------

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ the variables that are renamed:
 | FC                | OPENBLAS_FC           |
 | HOSTCC            | OPENBLAS_HOSTCC       |
 | RANLIB            | OPENBLAS_RANLIB       |
+| DYNAMIC_ARCH      | OPENBLAS_DYNAMIC_ARCH |
+| USE_THREAD        | OPENBLAS_USE_THREAD   |
+| USE_OPENMP        | OPENBLAS_USE_OPENMP   |
 
 ### Variables emitted by build.rs
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ the variables that are renamed:
 | DYNAMIC_ARCH      | OPENBLAS_DYNAMIC_ARCH |
 | USE_THREAD        | OPENBLAS_USE_THREAD   |
 | USE_OPENMP        | OPENBLAS_USE_OPENMP   |
+| USE_LOCKING       | OPENBLAS_USE_LOCKING  |
+| NUM_THREADS       | OPENBLAS_NUM_THREADS  |
+| NUM_PARALLEL      | OPENBLAS_NUM_PARALLEL |
 
 ### Variables emitted by build.rs
 

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -418,6 +418,9 @@ impl Configure {
         if self.use_openmp {
             args.push("USE_OPENMP=1".into());
         }
+        if self.dynamic_arch {
+            args.push("DYNAMIC_ARCH=1".into());
+        }
         if matches!(self.interface, Interface::ILP64) {
             args.push("INTERFACE64=1".into());
         }

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -365,7 +365,10 @@ pub struct Configure {
     pub no_lapacke: bool,
     pub use_thread: bool,
     pub use_openmp: bool,
+    pub use_locking: bool,
     pub dynamic_arch: bool,
+    pub num_threads: Option<u32>,
+    pub num_parallel: Option<u32>,
     pub interface: Interface,
     pub target: Option<Target>,
     pub compilers: Compilers,
@@ -381,7 +384,10 @@ impl Default for Configure {
             no_lapacke: false,
             use_thread: false,
             use_openmp: false,
+            use_locking: false,
             dynamic_arch: false,
+            num_threads: None,
+            num_parallel: None,
             interface: Interface::LP64,
             target: None,
             compilers: Compilers::default(),
@@ -418,8 +424,17 @@ impl Configure {
         if self.use_openmp {
             args.push("USE_OPENMP=1".into());
         }
+        if self.use_locking {
+            args.push("USE_LOCKING=1".into());
+        }
         if self.dynamic_arch {
             args.push("DYNAMIC_ARCH=1".into());
+        }
+        if let Some(num_threads) = self.num_threads {
+            args.push(format!("NUM_THREADS={}", num_threads));
+        }
+        if let Some(num_parallel) = self.num_parallel {
+            args.push(format!("NUM_PARALLEL={}", num_parallel));
         }
         if matches!(self.interface, Interface::ILP64) {
             args.push("INTERFACE64=1".into());

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -145,6 +145,9 @@ fn build() {
     println!("cargo:rerun-if-env-changed=OPENBLAS_DYNAMIC_ARCH");
     println!("cargo:rerun-if-env-changed=OPENBLAS_USE_THREAD");
     println!("cargo:rerun-if-env-changed=OPENBLAS_USE_OPENMP");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_USE_LOCKING");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_NUM_THREADS");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_NUM_PARALLEL");
     let mut cfg = openblas_build::Configure::default();
     if !feature_enabled("cblas") {
         cfg.no_cblas = true;
@@ -173,6 +176,15 @@ fn build() {
     cfg.dynamic_arch = env::var("OPENBLAS_DYNAMIC_ARCH").is_ok();
     cfg.use_thread = env::var("OPENBLAS_USE_THREAD").is_ok();
     cfg.use_openmp = env::var("OPENBLAS_USE_OPENMP").is_ok();
+    cfg.use_locking = env::var("OPENBLAS_USE_LOCKING").is_ok();
+    cfg.num_threads = env::var("OPENBLAS_NUM_THREADS").ok().map(|v| {
+        v.parse()
+            .expect("Invalid integer specified by $OPENBLAS_NUM_THREADS")
+    });
+    cfg.num_parallel = env::var("OPENBLAS_NUM_PARALLEL").ok().map(|v| {
+        v.parse()
+            .expect("Invalid integer specified by $OPENBLAS_NUM_PARALLEL")
+    });
 
     let output = if feature_enabled("cache") {
         use std::{

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -142,6 +142,9 @@ fn build() {
     println!("cargo:rerun-if-env-changed=OPENBLAS_HOSTCC");
     println!("cargo:rerun-if-env-changed=OPENBLAS_FC");
     println!("cargo:rerun-if-env-changed=OPENBLAS_RANLIB");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_DYNAMIC_ARCH");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_USE_THREAD");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_USE_OPENMP");
     let mut cfg = openblas_build::Configure::default();
     if !feature_enabled("cblas") {
         cfg.no_cblas = true;
@@ -167,6 +170,9 @@ fn build() {
     cfg.compilers.hostcc = env::var("OPENBLAS_HOSTCC").ok();
     cfg.compilers.fc = env::var("OPENBLAS_FC").ok();
     cfg.compilers.ranlib = env::var("OPENBLAS_RANLIB").ok();
+    cfg.dynamic_arch = env::var("OPENBLAS_DYNAMIC_ARCH").is_ok();
+    cfg.use_thread = env::var("OPENBLAS_USE_THREAD").is_ok();
+    cfg.use_openmp = env::var("OPENBLAS_USE_OPENMP").is_ok();
 
     let output = if feature_enabled("cache") {
         use std::{


### PR DESCRIPTION
## Summary
- Pushes `DYNAMIC_ARCH=1` into the make args when `Configure.dynamic_arch` is set. That field existed on `Configure` but was never consumed — the flag it was supposed to set was silently dropped.
- Exposes the three `Configure` fields `dynamic_arch`, `use_thread`, and `use_openmp` via new env vars: `OPENBLAS_DYNAMIC_ARCH`, `OPENBLAS_USE_THREAD`, `OPENBLAS_USE_OPENMP` (matching the existing `OPENBLAS_*` rename convention).
- Documents the three new env vars in the README table and notes the change in CHANGELOG.

Fixes #106. Picks up the `DYNAMIC_ARCH`/`USE_THREAD`/`USE_OPENMP` portion of the abandoned #72 (the `NUM_THREADS` default from that PR is not included — `NUM_THREADS` is already passed through directly by OpenBLAS's Makefile from the environment).