### PR TITLE
Add rustls/native-tls feature flags for download TLS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The following Cargo features are supported:
 * `cblas` to build CBLAS (enabled by default),
 * `lapacke` to build LAPACKE (enabled by default),
 * `static` to link to OpenBLAS statically,
-* `system` to skip building the bundled OpenBLAS.
+* `system` to skip building the bundled OpenBLAS,
+* `rustls` to use rustls for downloading the OpenBLAS source (enabled by default),
+* `native-tls` to use platform-native TLS for downloading the OpenBLAS source.
 
 Note: On Windows, OpenBLAS can not be built from source. The `system` feature is 
 supposed to be used.

--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -12,15 +12,18 @@ readme = "../README.md"
 exclude = ["test_build/"]
 rust-version = "1.71.1"
 
+[features]
+default = ["rustls"]
+rustls = ["ureq/rustls"]
+native-tls = ["ureq/native-tls"]
+
 [dependencies]
 anyhow = "1.0.68"
 cc = "1.0"
 flate2 = "1.0.25"
 tar = "0.4.38"
 thiserror = "2.0"
-ureq = { version = "3.0", default-features = false, features = [
-    "native-tls",
-] }
+ureq = { version = "3.0", default-features = false }
 
 [dev-dependencies]
 walkdir = "2.0"

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -5,6 +5,9 @@ use ureq::{
     tls::{TlsConfig, TlsProvider},
 };
 
+#[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+compile_error!("openblas-build requires the `rustls` or `native-tls` feature to be enabled");
+
 const OPENBLAS_VERSION: &str = "0.3.32";
 
 pub fn openblas_source_url() -> String {
@@ -31,12 +34,13 @@ pub fn download(out_dir: &Path) -> Result<PathBuf> {
 }
 
 fn get_agent() -> ureq::Agent {
+    #[cfg(feature = "native-tls")]
+    let provider = TlsProvider::NativeTls;
+    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
+    let provider = TlsProvider::Rustls;
+
     Config::builder()
-        .tls_config(
-            TlsConfig::builder()
-                .provider(TlsProvider::NativeTls)
-                .build(),
-        )
+        .tls_config(TlsConfig::builder().provider(provider).build())
         .build()
         .new_agent()
 }

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -25,13 +25,15 @@ links = "openblas"
 rust-version = "1.71.1"
 
 [features]
-default = ["cblas", "lapacke"]
+default = ["cblas", "lapacke", "rustls"]
 
 cache = []
 cblas = []
 lapacke = []
 static = []
 system = []
+rustls = ["openblas-build/rustls"]
+native-tls = ["openblas-build/native-tls"]
 
 [dev-dependencies]
 libc = "0.2"
@@ -39,7 +41,7 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3.30"
 dirs = "6.0.0"
-openblas-build = { version = "=0.10.15", path = "../openblas-build" }
+openblas-build = { version = "=0.10.15", path = "../openblas-build", default-features = false }
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
Default to rustls so the OpenBLAS source download no longer pulls openssl/openssl-sys into every consumer's dependency graph. Users who need platform-native TLS can opt in via the `native-tls` feature.

Closes #153.