### PR TITLE
Bump tar from 0.4.38 to 0.4.45 to fix RUSTSEC-2026-0067 and RUSTSEC-2026-0068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # CHANGELOG
 
-[Unreleased](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.14...master)
+[Unreleased](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.15...master)
 -----------
+[0.10.15 - 2026-03-24](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.14...v0.10.15)
+-----------
+
+## What's Changed
+* Update OpenBLAS version to 0.3.32 by @Dirreke in https://github.com/blas-lapack-rs/openblas-src/pull/150
 
 [0.10.14 - 2026-01-28](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.13...v0.10.14)
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [Unreleased](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.15...master)
 -----------
+
+## What's Changed
+* Plumb `DYNAMIC_ARCH` through `openblas-build::Configure` (previously dead field) and expose `DYNAMIC_ARCH`, `USE_THREAD`, and `USE_OPENMP` via `OPENBLAS_DYNAMIC_ARCH`, `OPENBLAS_USE_THREAD`, and `OPENBLAS_USE_OPENMP` env vars in `openblas-src`. Fixes [#106](https://github.com/blas-lapack-rs/openblas-src/issues/106) and picks up the work abandoned in [#72](https://github.com/blas-lapack-rs/openblas-src/pull/72).
+
 [0.10.15 - 2026-03-24](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.14...v0.10.15)
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -----------
 
 ## What's Changed
-* Plumb `DYNAMIC_ARCH` through `openblas-build::Configure` (previously dead field) and expose `DYNAMIC_ARCH`, `USE_THREAD`, and `USE_OPENMP` via `OPENBLAS_DYNAMIC_ARCH`, `OPENBLAS_USE_THREAD`, and `OPENBLAS_USE_OPENMP` env vars in `openblas-src`. Fixes [#106](https://github.com/blas-lapack-rs/openblas-src/issues/106) and picks up the work abandoned in [#72](https://github.com/blas-lapack-rs/openblas-src/pull/72).
+* Plumb `DYNAMIC_ARCH` through `openblas-build::Configure` (previously dead field) and expose the threading-related build flags `DYNAMIC_ARCH`, `USE_THREAD`, `USE_OPENMP`, `USE_LOCKING`, `NUM_THREADS`, and `NUM_PARALLEL` via the corresponding `OPENBLAS_*` env vars in `openblas-src`. Fixes [#106](https://github.com/blas-lapack-rs/openblas-src/issues/106) and picks up the work abandoned in [#72](https://github.com/blas-lapack-rs/openblas-src/pull/72).
 
 [0.10.15 - 2026-03-24](https://github.com/blas-lapack-rs/openblas-src/compare/openblas-src-v0.10.14...v0.10.15)
 -----------

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ the variables that are renamed:
 | FC                | OPENBLAS_FC           |
 | HOSTCC            | OPENBLAS_HOSTCC       |
 | RANLIB            | OPENBLAS_RANLIB       |
+| DYNAMIC_ARCH      | OPENBLAS_DYNAMIC_ARCH |
+| USE_THREAD        | OPENBLAS_USE_THREAD   |
+| USE_OPENMP        | OPENBLAS_USE_OPENMP   |
 
 ### Variables emitted by build.rs
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ the variables that are renamed:
 | DYNAMIC_ARCH      | OPENBLAS_DYNAMIC_ARCH |
 | USE_THREAD        | OPENBLAS_USE_THREAD   |
 | USE_OPENMP        | OPENBLAS_USE_OPENMP   |
+| USE_LOCKING       | OPENBLAS_USE_LOCKING  |
+| NUM_THREADS       | OPENBLAS_NUM_THREADS  |
+| NUM_PARALLEL      | OPENBLAS_NUM_PARALLEL |
 
 ### Variables emitted by build.rs
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The following Cargo features are supported:
 * `cblas` to build CBLAS (enabled by default),
 * `lapacke` to build LAPACKE (enabled by default),
 * `static` to link to OpenBLAS statically,
-* `system` to skip building the bundled OpenBLAS.
+* `system` to skip building the bundled OpenBLAS,
+* `rustls` to use rustls for downloading the OpenBLAS source (enabled by default),
+* `native-tls` to use platform-native TLS for downloading the OpenBLAS source.
 
 Note: On Windows, OpenBLAS can not be built from source. The `system` feature is 
 supposed to be used.

--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openblas-build"
-version = "0.10.14"
+version = "0.10.15"
 license = "Apache-2.0/MIT"
 edition = "2018"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]

--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -12,15 +12,18 @@ readme = "../README.md"
 exclude = ["test_build/"]
 rust-version = "1.71.1"
 
+[features]
+default = ["rustls"]
+rustls = ["ureq/rustls"]
+native-tls = ["ureq/native-tls"]
+
 [dependencies]
 anyhow = "1.0.68"
 cc = "1.0"
 flate2 = "1.0.25"
 tar = "0.4.38"
 thiserror = "2.0"
-ureq = { version = "3.0", default-features = false, features = [
-    "native-tls",
-] }
+ureq = { version = "3.0", default-features = false }
 
 [dev-dependencies]
 walkdir = "2.0"

--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -21,7 +21,7 @@ native-tls = ["ureq/native-tls"]
 anyhow = "1.0.68"
 cc = "1.0"
 flate2 = "1.0.25"
-tar = "0.4.38"
+tar = "0.4.45"
 thiserror = "2.0"
 ureq = { version = "3.0", default-features = false }
 

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -418,6 +418,9 @@ impl Configure {
         if self.use_openmp {
             args.push("USE_OPENMP=1".into());
         }
+        if self.dynamic_arch {
+            args.push("DYNAMIC_ARCH=1".into());
+        }
         if matches!(self.interface, Interface::ILP64) {
             args.push("INTERFACE64=1".into());
         }

--- a/openblas-build/src/build.rs
+++ b/openblas-build/src/build.rs
@@ -365,7 +365,10 @@ pub struct Configure {
     pub no_lapacke: bool,
     pub use_thread: bool,
     pub use_openmp: bool,
+    pub use_locking: bool,
     pub dynamic_arch: bool,
+    pub num_threads: Option<u32>,
+    pub num_parallel: Option<u32>,
     pub interface: Interface,
     pub target: Option<Target>,
     pub compilers: Compilers,
@@ -381,7 +384,10 @@ impl Default for Configure {
             no_lapacke: false,
             use_thread: false,
             use_openmp: false,
+            use_locking: false,
             dynamic_arch: false,
+            num_threads: None,
+            num_parallel: None,
             interface: Interface::LP64,
             target: None,
             compilers: Compilers::default(),
@@ -418,8 +424,17 @@ impl Configure {
         if self.use_openmp {
             args.push("USE_OPENMP=1".into());
         }
+        if self.use_locking {
+            args.push("USE_LOCKING=1".into());
+        }
         if self.dynamic_arch {
             args.push("DYNAMIC_ARCH=1".into());
+        }
+        if let Some(num_threads) = self.num_threads {
+            args.push(format!("NUM_THREADS={}", num_threads));
+        }
+        if let Some(num_parallel) = self.num_parallel {
+            args.push(format!("NUM_PARALLEL={}", num_parallel));
         }
         if matches!(self.interface, Interface::ILP64) {
             args.push("INTERFACE64=1".into());

--- a/openblas-build/src/download.rs
+++ b/openblas-build/src/download.rs
@@ -5,6 +5,9 @@ use ureq::{
     tls::{TlsConfig, TlsProvider},
 };
 
+#[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+compile_error!("openblas-build requires the `rustls` or `native-tls` feature to be enabled");
+
 const OPENBLAS_VERSION: &str = "0.3.32";
 
 pub fn openblas_source_url() -> String {
@@ -31,12 +34,13 @@ pub fn download(out_dir: &Path) -> Result<PathBuf> {
 }
 
 fn get_agent() -> ureq::Agent {
+    #[cfg(feature = "native-tls")]
+    let provider = TlsProvider::NativeTls;
+    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
+    let provider = TlsProvider::Rustls;
+
     Config::builder()
-        .tls_config(
-            TlsConfig::builder()
-                .provider(TlsProvider::NativeTls)
-                .build(),
-        )
+        .tls_config(TlsConfig::builder().provider(provider).build())
         .build()
         .new_agent()
 }

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openblas-src"
-version = "0.10.14"
+version = "0.10.15"
 license = "Apache-2.0/MIT"
 edition = "2018"
 authors = [
@@ -39,7 +39,7 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3.30"
 dirs = "6.0.0"
-openblas-build = { version = "0.10.14", path = "../openblas-build" }
+openblas-build = { version = "=0.10.15", path = "../openblas-build" }
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"

--- a/openblas-src/Cargo.toml
+++ b/openblas-src/Cargo.toml
@@ -25,13 +25,15 @@ links = "openblas"
 rust-version = "1.71.1"
 
 [features]
-default = ["cblas", "lapacke"]
+default = ["cblas", "lapacke", "rustls"]
 
 cache = []
 cblas = []
 lapacke = []
 static = []
 system = []
+rustls = ["openblas-build/rustls"]
+native-tls = ["openblas-build/native-tls"]
 
 [dev-dependencies]
 libc = "0.2"
@@ -39,7 +41,7 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3.30"
 dirs = "6.0.0"
-openblas-build = { version = "=0.10.15", path = "../openblas-build" }
+openblas-build = { version = "=0.10.15", path = "../openblas-build", default-features = false }
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -145,6 +145,9 @@ fn build() {
     println!("cargo:rerun-if-env-changed=OPENBLAS_DYNAMIC_ARCH");
     println!("cargo:rerun-if-env-changed=OPENBLAS_USE_THREAD");
     println!("cargo:rerun-if-env-changed=OPENBLAS_USE_OPENMP");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_USE_LOCKING");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_NUM_THREADS");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_NUM_PARALLEL");
     let mut cfg = openblas_build::Configure::default();
     if !feature_enabled("cblas") {
         cfg.no_cblas = true;
@@ -173,6 +176,15 @@ fn build() {
     cfg.dynamic_arch = env::var("OPENBLAS_DYNAMIC_ARCH").is_ok();
     cfg.use_thread = env::var("OPENBLAS_USE_THREAD").is_ok();
     cfg.use_openmp = env::var("OPENBLAS_USE_OPENMP").is_ok();
+    cfg.use_locking = env::var("OPENBLAS_USE_LOCKING").is_ok();
+    cfg.num_threads = env::var("OPENBLAS_NUM_THREADS").ok().map(|v| {
+        v.parse()
+            .expect("Invalid integer specified by $OPENBLAS_NUM_THREADS")
+    });
+    cfg.num_parallel = env::var("OPENBLAS_NUM_PARALLEL").ok().map(|v| {
+        v.parse()
+            .expect("Invalid integer specified by $OPENBLAS_NUM_PARALLEL")
+    });
 
     let output = if feature_enabled("cache") {
         use std::{

--- a/openblas-src/build.rs
+++ b/openblas-src/build.rs
@@ -142,6 +142,9 @@ fn build() {
     println!("cargo:rerun-if-env-changed=OPENBLAS_HOSTCC");
     println!("cargo:rerun-if-env-changed=OPENBLAS_FC");
     println!("cargo:rerun-if-env-changed=OPENBLAS_RANLIB");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_DYNAMIC_ARCH");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_USE_THREAD");
+    println!("cargo:rerun-if-env-changed=OPENBLAS_USE_OPENMP");
     let mut cfg = openblas_build::Configure::default();
     if !feature_enabled("cblas") {
         cfg.no_cblas = true;
@@ -167,6 +170,9 @@ fn build() {
     cfg.compilers.hostcc = env::var("OPENBLAS_HOSTCC").ok();
     cfg.compilers.fc = env::var("OPENBLAS_FC").ok();
     cfg.compilers.ranlib = env::var("OPENBLAS_RANLIB").ok();
+    cfg.dynamic_arch = env::var("OPENBLAS_DYNAMIC_ARCH").is_ok();
+    cfg.use_thread = env::var("OPENBLAS_USE_THREAD").is_ok();
+    cfg.use_openmp = env::var("OPENBLAS_USE_OPENMP").is_ok();
 
     let output = if feature_enabled("cache") {
         use std::{


### PR DESCRIPTION
[RUSTSEC-2026-0067](https://osv.dev/vulnerability/RUSTSEC-2026-0067)
[RUSTSEC-2026-0068](https://osv.dev/vulnerability/RUSTSEC-2026-0068)