### PR TITLE
Bump tar from 0.4.38 to 0.4.45, due to RUSTSEC-2026-0067 and RUSTSEC-2026-0068

### DIFF
--- a/openblas-build/Cargo.toml
+++ b/openblas-build/Cargo.toml
@@ -21,7 +21,7 @@ native-tls = ["ureq/native-tls"]
 anyhow = "1.0.68"
 cc = "1.0"
 flate2 = "1.0.25"
-tar = "0.4.38"
+tar = "0.4.45"
 thiserror = "2.0"
 ureq = { version = "3.0", default-features = false }
 


### PR DESCRIPTION
[RUSTSEC-2026-0067](https://osv.dev/vulnerability/RUSTSEC-2026-0067)
[RUSTSEC-2026-0068](https://osv.dev/vulnerability/RUSTSEC-2026-0068)